### PR TITLE
Add support for the QMC5883p, and general cleanup in drivers

### DIFF
--- a/src/sensor/calibration.c
+++ b/src/sensor/calibration.c
@@ -358,7 +358,7 @@ static void sensor_calibrate_imu()
 		LOG_INF("Suspending sensor thread");
 		main_imu_suspend();
 		LOG_INF("Running BMI270 component retrimming");
-		int err = bmi_crt(sensor_data); // will automatically reinitialize // TODO: this blocks sensor!
+		int err = bmi270_crt(sensor_data); // will automatically reinitialize // TODO: this blocks sensor!
 		LOG_INF("Resuming sensor thread");
 		main_imu_resume();
 		if (err)

--- a/src/sensor/imu/BMI270.c
+++ b/src/sensor/imu/BMI270.c
@@ -35,7 +35,7 @@ static int asic_init(void);
 static int upload_config_file(void);
 static int factor_zx_read(void);
 
-int bmi_init(float clock_rate, float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time)
+int bmi270_init(float clock_rate, float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time)
 {
 	// setup interface for SPI
 	sensor_interface_spi_configure(SENSOR_INTERFACE_DEV_IMU, MHZ(10), 1);
@@ -48,7 +48,7 @@ int bmi_init(float clock_rate, float accel_time, float gyro_time, float *accel_a
 	last_gyro_odr = 0xff; // reset last odr
 	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, BMI270_ACC_RANGE, accel_fs);
 	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, BMI270_GYR_RANGE, gyro_fs);
-	err |= bmi_update_odr(accel_time, gyro_time, accel_actual_time, gyro_actual_time);
+	err |= bmi270_update_odr(accel_time, gyro_time, accel_actual_time, gyro_actual_time);
 	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, BMI270_FIFO_CONFIG_0, 0x00); // do not return sensortime frame
 	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, BMI270_FIFO_CONFIG_1, 0xC0); // enable a+g data in FIFO, don't store header
 	if (err)
@@ -56,7 +56,7 @@ int bmi_init(float clock_rate, float accel_time, float gyro_time, float *accel_a
 	return (err < 0 ? err : 0);
 }
 
-void bmi_shutdown(void) // this does not reset the device, to avoid clearing the config
+void bmi270_shutdown(void) // this does not reset the device, to avoid clearing the config
 {
 	last_accel_odr = 0xff; // reset last odr
 	last_gyro_odr = 0xff; // reset last odr
@@ -66,7 +66,7 @@ void bmi_shutdown(void) // this does not reset the device, to avoid clearing the
 		LOG_ERR("Communication error");
 }
 
-void bmi_update_fs(float accel_range, float gyro_range, float *accel_actual_range, float *gyro_actual_range)
+void bmi270_update_fs(float accel_range, float gyro_range, float *accel_actual_range, float *gyro_actual_range)
 {
 	if (accel_range < 0)
 		accel_range = 0;
@@ -99,7 +99,7 @@ void bmi_update_fs(float accel_range, float gyro_range, float *accel_actual_rang
 	*gyro_actual_range = gyro_range;
 }
 
-int bmi_update_odr(float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time)
+int bmi270_update_odr(float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time)
 {
 	int interval;
 	uint8_t acc_odr = 0;
@@ -164,7 +164,7 @@ int bmi_update_odr(float accel_time, float gyro_time, float *accel_actual_time, 
 }
 
 // TODO: gyro rotation data is delayed for some reason, accelerometer still responds instantly
-uint16_t bmi_fifo_read(uint8_t *data, uint16_t len)
+uint16_t bmi270_fifo_read(uint8_t *data, uint16_t len)
 {
 	int err = 0;
 	uint16_t total = 0;
@@ -198,7 +198,7 @@ static const uint8_t overread[2] = {0x00, 0x80};
 static const uint8_t invalid_accel[6] = {0x01, 0x7F, 0x00, 0x80, 0x00, 0x80};
 static const uint8_t invalid_gyro[6] = {0x02, 0x7F, 0x00, 0x80, 0x00, 0x80};
 
-int bmi_fifo_process(uint16_t index, uint8_t *data, float a[3], float g[3])
+int bmi270_fifo_process(uint16_t index, uint8_t *data, float a[3], float g[3])
 {
 	index *= PACKET_SIZE;
 	if (!memcmp(&data[index], overread, sizeof(overread)))
@@ -229,7 +229,7 @@ int bmi_fifo_process(uint16_t index, uint8_t *data, float a[3], float g[3])
 	return 0;
 }
 
-void bmi_accel_read(float a[3])
+void bmi270_accel_read(float a[3])
 {
 	uint8_t rawAccel[6];
 	int err = ssi_burst_read(SENSOR_INTERFACE_DEV_IMU, BMI270_DATA_8, &rawAccel[0], 6);
@@ -246,7 +246,7 @@ void bmi_accel_read(float a[3])
 	a[2] = a_bmi[2];
 }
 
-void bmi_gyro_read(float g[3])
+void bmi270_gyro_read(float g[3])
 {
 	uint8_t rawGyro[6];
 	int err = ssi_burst_read(SENSOR_INTERFACE_DEV_IMU, BMI270_DATA_14, &rawGyro[0], 6);
@@ -265,7 +265,7 @@ void bmi_gyro_read(float g[3])
 	g[2] = g_bmi[2];
 }
 
-int bmi_temp_read(float *data)
+int bmi270_temp_read(float *data)
 {
 	uint8_t rawTemp[2];
 	int err = ssi_burst_read(SENSOR_INTERFACE_DEV_IMU, BMI270_TEMPERATURE_0, &rawTemp[0], 2);
@@ -284,7 +284,7 @@ int bmi_temp_read(float *data)
 	return 0;
 }
 
-uint8_t bmi_setup_DRDY(uint16_t threshold)
+uint8_t bmi270_setup_DRDY(uint16_t threshold)
 {
 	uint8_t buf[2];
 	threshold *= PACKET_SIZE; // byte threshold
@@ -299,7 +299,7 @@ uint8_t bmi_setup_DRDY(uint16_t threshold)
 	return NRF_GPIO_PIN_PULLUP << 4 | NRF_GPIO_PIN_SENSE_LOW; // active low
 }
 
-uint8_t bmi_setup_WOM(void) // TODO: seems too sensitive? try to match icm at least // TODO: half working.
+uint8_t bmi270_setup_WOM(void) // TODO: seems too sensitive? try to match icm at least // TODO: half working.
 {
 	uint8_t config[4] = {0};
 	uint16_t *ptr = (uint16_t *)config; // bmi is little endian
@@ -390,7 +390,7 @@ static int factor_zx_read(void)
 }
 
 // from https://github.com/SlimeVR/SlimeVR-Tracker-ESP/blob/main/src/sensors/softfusion/drivers/bmi270.h
-int bmi_crt(uint8_t *data)
+int bmi270_crt(uint8_t *data)
 {
 	uint8_t status;
 	uint8_t acc_odr = last_accel_odr; // store last odr
@@ -447,7 +447,7 @@ int bmi_crt(uint8_t *data)
 	// in case of SPI, where CS pin must trigger rising edge for BMI to enable interface
 	err |= ssi_reg_read_byte(SENSOR_INTERFACE_DEV_IMU, 0x00, &tmp);
 	k_usleep(200);
-	bmi_init(0, 0, 0, 0, 0);
+	bmi270_init(0, 0, 0, 0, 0);
 	if (acc_odr != 0)
 		err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, BMI270_ACC_CONF, 0xA0 | acc_odr);
 	if (gyr_odr != 0)
@@ -464,7 +464,7 @@ int bmi_crt(uint8_t *data)
 	return 0;
 }
 
-void bmi_gain_apply(uint8_t *data)
+void bmi270_gain_apply(uint8_t *data)
 {
 	if (data[0] == 1) // flag for valid gain
 	{
@@ -474,21 +474,21 @@ void bmi_gain_apply(uint8_t *data)
 }
 
 const sensor_imu_t sensor_imu_bmi270 = {
-	*bmi_init,
-	*bmi_shutdown,
+	*bmi270_init,
+	*bmi270_shutdown,
 
-	*bmi_update_fs,
-	*bmi_update_odr,
+	*bmi270_update_fs,
+	*bmi270_update_odr,
 
-	*bmi_fifo_read,
-	*bmi_fifo_process,
-	*bmi_accel_read,
-	*bmi_gyro_read,
-	*bmi_temp_read,
+	*bmi270_fifo_read,
+	*bmi270_fifo_process,
+	*bmi270_accel_read,
+	*bmi270_gyro_read,
+	*bmi270_temp_read,
 
-	*bmi_setup_DRDY,
-	*bmi_setup_WOM,
-
+	*bmi270_setup_DRDY,
+	*bmi270_setup_WOM,
+	
 	*imu_none_ext_setup,
 	*imu_none_ext_passthrough
 };

--- a/src/sensor/imu/BMI270.h
+++ b/src/sensor/imu/BMI270.h
@@ -75,23 +75,23 @@
 #define RANGE_250  0x03
 #define RANGE_125  0x04
 
-int bmi_init(float clock_rate, float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time);
-void bmi_shutdown(void);
+int bmi270_init(float clock_rate, float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time);
+void bmi270_shutdown(void);
 
-void bmi_update_fs(float accel_range, float gyro_range, float *accel_actual_range, float *gyro_actual_range);
-int bmi_update_odr(float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time);
+void bmi270_update_fs(float accel_range, float gyro_range, float *accel_actual_range, float *gyro_actual_range);
+int bmi270_update_odr(float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time);
 
-uint16_t bmi_fifo_read(uint8_t *data, uint16_t len);
-int bmi_fifo_process(uint16_t index, uint8_t *data, float a[3], float g[3]);
-void bmi_accel_read(float a[3]);
-void bmi_gyro_read(float g[3]);
-int bmi_temp_read(float *data);
+uint16_t bmi270_fifo_read(uint8_t *data, uint16_t len);
+int bmi270_fifo_process(uint16_t index, uint8_t *data, float a[3], float g[3]);
+void bmi270_accel_read(float a[3]);
+void bmi270_gyro_read(float g[3]);
+int bmi270_temp_read(float *data);
 
-uint8_t bmi_setup_DRDY(uint16_t threshold);
-uint8_t bmi_setup_WOM(void);
+uint8_t bmi270_setup_DRDY(uint16_t threshold);
+uint8_t bmi270_setup_WOM(void);
 
-int bmi_crt(uint8_t *data);
-void bmi_gain_apply(uint8_t *data);
+int bmi270_crt(uint8_t *data);
+void bmi270_gain_apply(uint8_t *data);
 
 extern const sensor_imu_t sensor_imu_bmi270;
 

--- a/src/sensor/mag/QMC5883P.c
+++ b/src/sensor/mag/QMC5883P.c
@@ -1,0 +1,192 @@
+#include <math.h>
+
+#include <zephyr/logging/log.h>
+
+#include "sensor/sensor_none.h"
+
+#include "QMC5883P.h"
+
+LOG_MODULE_REGISTER(QMC5883P, LOG_LEVEL_INF);
+
+#define ODR_1Hz  0b000
+#define ODR_10Hz  0b001
+#define ODR_50Hz  0b010
+#define ODR_100Hz 0b011
+#define ODR_200Hz 0b100
+#define ODR_MASK(odr) ((odr) << 2)
+
+#define OSR_OFF 0b11
+#define OSR_2 0b10
+#define OSR_4 0b01
+#define OSR_8 0b00
+#define OSR_MASK(osr) ((osr) << 6)
+
+// Device supports 30G, 12G, 8G, and 2G
+// Datasheet isn't 100% clear on what it should be, this was decoded from what the DS says to init with
+#define RNG_2G 0b00
+#define RNG_8G 0b01
+#define RNG_MASK(x) (((x) & 0x03) << 4)
+
+// ±8 G mode=3750 LSB/G, ~0.267 mG/LSB
+static const float sensitivity = 1.0f / 3750.0f;
+
+static uint8_t last_ctrl1 = 0xFF;
+static uint8_t last_ctrl2 = 0xFF;
+static bool overflow_latched = false;
+
+int qmc5883p_init(float time, float *actual_time)
+{
+	uint8_t id = 0;
+	int err = ssi_reg_read_byte(SENSOR_INTERFACE_DEV_MAG, QMC5883P_CHIP_ID_REG, &id);
+	if (id != 0x80) {
+		LOG_ERR("QMC5883P: invalid WHOAMI=0x%02X", id);
+		return -ENODEV;
+	}
+
+	// Define the sign for X, Y & Z
+	// Registers 01H ~ 06H store the measurement data from each axis magnetic sensor in each working mode
+	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_MAG, QMC5883P_AXIS_SIGN_REG, QMC5883P_OUTZ_M_REG);
+	k_msleep(5);
+
+	uint8_t ctrl2 = QMC5883P_RNG_8G | QMC5883P_SET_RESET_ON;
+	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_MAG, QMC5883P_CTRL2_REG, ctrl2);
+	last_ctrl2 = ctrl2;
+	k_msleep(5);
+
+	err |= qmc5883p_update_odr(time, actual_time);
+	overflow_latched = false;
+
+	if (err)
+		LOG_ERR("Communication error");
+
+	return 0;
+}
+
+void qmc5883p_shutdown(void)
+{
+	int err = ssi_reg_write_byte(SENSOR_INTERFACE_DEV_MAG, QMC5883P_CTRL1_REG, QMC5883P_MODE_SUSPEND);
+	k_msleep(5);
+	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_MAG, QMC5883P_CTRL2_REG, QMC5883P_SOFT_RST);
+	if (err)
+		LOG_ERR("Communication error");
+}
+
+int qmc5883p_update_odr(float time, float *actual_time)
+{
+	int ODR;
+	uint8_t MODR;
+	uint8_t MD;
+
+	if (time <= 0 || time == INFINITY) // power down mode or single measurement mode
+	{
+		MD = QMC5883P_MODE_SUSPEND; // oneshot will set SINGLE after
+		ODR = 0;
+	}
+	else
+	{
+		MD = QMC5883P_MODE_CONT;
+		ODR = 1 / time;
+	}
+
+	if (MD == QMC5883P_MODE_SUSPEND)
+	{
+		MODR = ODR_200Hz; // for oneshot
+		time = 0; // off
+	}
+	else if (ODR > 100)
+	{
+		MODR = ODR_200Hz;
+		time = 1.f / 200;
+	}
+	else if (ODR > 50)
+	{
+		MODR = ODR_100Hz;
+		time = 1.f / 100;
+	}
+	else if (ODR > 25)
+	{
+		MODR = ODR_50Hz;
+		time = 1.f / 50;
+	}
+	else if (ODR > 5)
+	{
+		MODR = ODR_10Hz;
+		time = 1.f / 10;
+	}
+	else
+	{
+		MODR = ODR_1Hz;
+		time = 1.f;
+	}
+
+	*actual_time = time;
+
+	uint8_t ctrl1 = OSR_MASK(OSR_2) | ODR_MASK(MODR) | RNG_MASK(RNG_8G) | QMC5883P_MODE_NORMAL;
+	if (ctrl1 == last_ctrl1)
+		return 0;
+
+	ssi_reg_write_byte(SENSOR_INTERFACE_DEV_MAG, QMC5883P_CTRL1_REG, ctrl1);
+
+	last_ctrl1 = ctrl1;
+	return 0;
+}
+
+void qmc5883p_mag_oneshot(void)
+{
+	int err = ssi_reg_write_byte(SENSOR_INTERFACE_DEV_MAG, QMC5883P_CTRL1_REG, OSR_MASK(OSR_8) | ODR_MASK(ODR_200Hz) | RNG_MASK(RNG_8G) | QMC5883P_MODE_SINGLE);
+	if (err)
+		LOG_ERR("Communication error");
+	k_usleep(5000);
+}
+
+void qmc5883p_mag_read(float m[3])
+{
+	uint8_t status;
+	int err = ssi_reg_read_byte(SENSOR_INTERFACE_DEV_MAG, QMC5883P_STATUS_REG, &status);
+	if (err)
+		return;
+
+	if (!(status & QMC5883P_STAT_DRDY))
+		return;
+
+	if ((status & QMC5883P_STAT_OVFL) && !overflow_latched)
+	{
+		LOG_WRN("QMC5883P: magnetic overflow detected");
+		overflow_latched = true;
+	}
+
+	uint8_t rawData[6];
+	for (int i = 0; i < 6; i++)
+	{
+		// Burst can cause issues, so we just read each byte one by one
+		ssi_reg_read_byte(SENSOR_INTERFACE_DEV_MAG, QMC5883P_OUTX_L_REG + i, &rawData[i]);
+	}
+
+	qmc5883p_mag_process(rawData, m);
+}
+
+void qmc5883p_mag_process(uint8_t *raw_m, float m[3])
+{
+	int16_t *s16 = (int16_t *)raw_m;
+	for (int i = 0; i < 3; i++)
+		m[i] = s16[i] * sensitivity; // in Gauss
+}
+
+const sensor_mag_t sensor_mag_qmc5883p = {
+	*qmc5883p_init,
+	*qmc5883p_shutdown,
+
+	*qmc5883p_update_odr,
+
+	*qmc5883p_mag_oneshot,
+	*qmc5883p_mag_read,
+	// From the datasheet:
+	// The Device has built-in Temperature compensation function. The compensated magnetic sensor data is placed
+	// in the Output Data Registers automatically
+	//
+	// This means we do not have a temp register to read from, so we just ignore it
+	*mag_none_temp_read,
+
+	*qmc5883p_mag_process,
+	6, 6
+};

--- a/src/sensor/mag/QMC5883P.h
+++ b/src/sensor/mag/QMC5883P.h
@@ -1,0 +1,52 @@
+#ifndef QMC5883_h
+#define QMC5883_h
+
+#include "sensor/sensor.h"
+
+#define QMC588P_DEVADDR          0x2C
+#define QMC5883P_CHIP_ID_REG     0x00
+#define QMC5883P_OUTX_L_REG      0x01
+#define QMC5883P_OUTX_M_REG      0x02
+#define QMC5883P_OUTY_L_REG      0x03
+#define QMC5883P_OUTY_M_REG      0x04
+#define QMC5883P_OUTZ_L_REG      0x05
+#define QMC5883P_OUTZ_M_REG      0x06
+#define QMC5883P_STATUS_REG      0x09
+#define QMC5883P_CTRL1_REG       0x0A
+#define QMC5883P_CTRL2_REG       0x0B
+#define QMC5883P_AXIS_SIGN_REG   0x29
+
+// Status bits
+#define QMC5883P_STAT_DRDY       0x01
+#define QMC5883P_STAT_OVFL       0x02
+
+// Control1 bits: OSR2<1:0> OSR1<1:0> ODR<1:0> MODE<1:0>
+#define QMC5883P_MODE_SUSPEND    0x00
+#define QMC5883P_MODE_NORMAL     0x01
+#define QMC5883P_MODE_SINGLE     0x02
+#define QMC5883P_MODE_CONT       0x03
+
+// Control2 bits: SOFT_RST SELF_TEST -- RNG<1:0> SET/RESET<1:0>
+#define QMC5883P_SOFT_RST        0x80
+#define QMC5883P_SELF_TEST       0x40
+#define QMC5883P_RNG_2G          (0b11 << 4)
+#define QMC5883P_RNG_8G          (0b10 << 4)
+#define QMC5883P_RNG_12G         (0b01 << 4)
+#define QMC5883P_RNG_30G         (0b00 << 4)
+#define QMC5883P_SET_RESET_ON    0x00   // per Table 18:contentReference[oaicite:1]{index=1}
+#define QMC5883P_SET_ONLY        0x10
+
+int qmc5883p_init(float time, float *actual_time);
+void qmc5883p_shutdown(void);
+
+int qmc5883p_update_odr(float time, float *actual_time);
+
+void qmc5883p_mag_oneshot(void);
+
+void qmc5883p_mag_read(float m[3]);
+
+void qmc5883p_mag_process(uint8_t *raw_m, float m[3]);
+
+extern const sensor_mag_t sensor_mag_qmc5883p;
+
+#endif

--- a/src/sensor/mag/QMC6309.c
+++ b/src/sensor/mag/QMC6309.c
@@ -67,16 +67,16 @@ static int64_t oneshot_trigger_time = 0;
 
 LOG_MODULE_REGISTER(QMC6309, LOG_LEVEL_INF);
 
-int qmc_init(float time, float *actual_time)
+int qmc6309_init(float time, float *actual_time)
 {
 	last_state = 0xff; // init state
 	lastOvfl = false;
 	oneshot_trigger_time = 0;
-	int err = qmc_update_odr(time, actual_time);
+	int err = qmc6309_update_odr(time, actual_time);
 	return (err < 0 ? err : 0);
 }
 
-void qmc_shutdown(void)
+void qmc6309_shutdown(void)
 {
 	int err = ssi_reg_write_byte(SENSOR_INTERFACE_DEV_MAG, QMC6309_CTRL_REG_2, SOFT_RESET_MASK);
 	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_MAG, QMC6309_CTRL_REG_2, SOFT_RESET_CLEAR);
@@ -84,7 +84,7 @@ void qmc_shutdown(void)
 		LOG_ERR("Communication error");
 }
 
-int qmc_update_odr(float time, float *actual_time)
+int qmc6309_update_odr(float time, float *actual_time)
 {
 	int ODR;
 	uint8_t MODR;
@@ -148,7 +148,7 @@ int qmc_update_odr(float time, float *actual_time)
 	return err;
 }
 
-void qmc_mag_oneshot(void)
+void qmc6309_mag_oneshot(void)
 {
 	int err = ssi_reg_write_byte(SENSOR_INTERFACE_DEV_MAG, QMC6309_CTRL_REG_1, LPF_MASK(LPF_2) | OSR_MASK(OSR_8) | MD_SINGLE);
 	oneshot_trigger_time = k_uptime_get();
@@ -156,7 +156,7 @@ void qmc_mag_oneshot(void)
 		LOG_ERR("Communication error");
 }
 
-void qmc_mag_read(float m[3])
+void qmc6309_mag_read(float m[3])
 {
 	int err = 0;
 	uint8_t status = 0; // Always check DRDY
@@ -188,10 +188,10 @@ void qmc_mag_read(float m[3])
 	err |= ssi_burst_read(SENSOR_INTERFACE_DEV_MAG, QMC6309_OUTX_L_REG, rawData, 6);
 	if (err)
 		LOG_ERR("Communication error");
-	qmc_mag_process(rawData, m);
+	qmc6309_mag_process(rawData, m);
 }
 
-void qmc_mag_process(uint8_t *raw_m, float m[3])
+void qmc6309_mag_process(uint8_t *raw_m, float m[3])
 {
 	for (int i = 0; i < 3; i++) // x, y, z
 	{
@@ -201,15 +201,15 @@ void qmc_mag_process(uint8_t *raw_m, float m[3])
 }
 
 const sensor_mag_t sensor_mag_qmc6309 = {
-	*qmc_init,
-	*qmc_shutdown,
+	*qmc6309_init,
+	*qmc6309_shutdown,
 
-	*qmc_update_odr,
+	*qmc6309_update_odr,
 
-	*qmc_mag_oneshot,
-	*qmc_mag_read,
+	*qmc6309_mag_oneshot,
+	*qmc6309_mag_read,
 	*mag_none_temp_read,
 
-	*qmc_mag_process,
+	*qmc6309_mag_process,
 	6, 6
 };

--- a/src/sensor/mag/QMC6309.h
+++ b/src/sensor/mag/QMC6309.h
@@ -3,15 +3,15 @@
 
 #include "sensor/sensor.h"
 
-int qmc_init(float time, float *actual_time);
-void qmc_shutdown(void);
+int qmc6309_init(float time, float *actual_time);
+void qmc6309_shutdown(void);
 
-int qmc_update_odr(float time, float *actual_time);
+int qmc6309_update_odr(float time, float *actual_time);
 
-void qmc_mag_oneshot(void);
-void qmc_mag_read(float m[3]);
+void qmc6309_mag_oneshot(void);
+void qmc6309_mag_read(float m[3]);
 
-void qmc_mag_process(uint8_t *raw_m, float m[3]);
+void qmc6309_mag_process(uint8_t *raw_m, float m[3]);
 
 extern const sensor_mag_t sensor_mag_qmc6309;
 

--- a/src/sensor/scan.c
+++ b/src/sensor/scan.c
@@ -72,6 +72,25 @@ int sensor_scan_i2c(struct i2c_dt_spec *i2c_dev, uint8_t *i2c_dev_reg, int dev_a
 			uint8_t dummy;
 			i2c_reg_read_byte(dev, addr, 0x00, &dummy);
 
+			// QMC5883P wakeup - device won't respond in some cases
+			if (addr == 0x2C)
+			{
+				uint8_t wake_seq[2] = { 0x09, 0x01 };
+				int err = i2c_write(dev, wake_seq, sizeof(wake_seq), addr);
+				if (!err)
+				{
+					LOG_INF("QMC5883P wakeup sequence sent to 0x2C");
+					k_msleep(10);
+					uint8_t id_byte = 0;
+					if (i2c_reg_read_byte(dev, addr, 0x00, &id_byte) == 0)
+						LOG_INF("QMC5883P probe: WHOAMI=0x%02X at 0x2C", id_byte);
+				}
+				else
+				{
+					LOG_WRN("Failed to wake QMC5883P at 0x2C (err=%d)", err);
+				}
+			}
+
 			int id_cnt = id_count;
 			int id_ind = id_index;
 			int fnd_id = found_id;

--- a/src/sensor/sensor.c
+++ b/src/sensor/sensor.c
@@ -732,7 +732,7 @@ int sensor_init(void)
 	if (sensor_imu == &sensor_imu_bmi270) // bmi270 specific
 	{
 		LOG_INF("Applying gyroscope gain");
-		bmi_gain_apply(sensor_calibration_get_sensor_data());
+		bmi270_gain_apply(sensor_calibration_get_sensor_data());
 	}
 
 #if IMU_INT_EXISTS

--- a/src/sensor/sensors.h
+++ b/src/sensor/sensors.h
@@ -43,6 +43,7 @@
 #include "mag/LIS2MDL.h"
 #include "mag/LIS3MDL.h"
 #include "mag/MMC5983MA.h"
+#include "mag/QMC5883P.h"
 #include "mag/QMC6309.h"
 
 #include "scan.h"
@@ -130,6 +131,7 @@ const char *dev_mag_names[] = {
 	"IST8320",
 	"IST8321",
 	"IIS2MDC/LIS2MDL",
+	"QMC5883P",
 	"LIS3MDL",
 	"MMC34160PJ",
 	"MMC3630KJ",
@@ -152,6 +154,7 @@ const sensor_mag_t *sensor_mags[] = {
 	&sensor_mag_none, // IST8320
 	&sensor_mag_none, // IST8321
 	&sensor_mag_lis2mdl,
+	&sensor_mag_qmc5883p, // QMC5883P / HP5883
 	&sensor_mag_lis3mdl,
 	&sensor_mag_none, // MMC34160
 	&sensor_mag_none, // MMC3630
@@ -159,7 +162,7 @@ const sensor_mag_t *sensor_mags[] = {
 	&sensor_mag_none, // MMC5616
 	&sensor_mag_mmc5983ma
 };
-const int i2c_dev_mag_addr_count = 11;
+const int i2c_dev_mag_addr_count = 12;
 const uint8_t i2c_dev_mag_addr[] = {
 	1,	0x0C,
 	1,	0x0D,
@@ -169,6 +172,7 @@ const uint8_t i2c_dev_mag_addr[] = {
 	1,	0x19,
 	1,	0x1C,
 	1,	0x1E,
+	1,	0x2C,
 	1,	0x30,
 	1,	0x3C,
 	1,	0x7C
@@ -189,6 +193,7 @@ const uint8_t i2c_dev_mag_reg[] = {
 	3,	0x0A,
 		0x0F,
 		0x4F,
+	1,	0x00,
 	3,	0x20,
 		0x2F,
 		0x39,
@@ -211,6 +216,7 @@ const uint8_t i2c_dev_mag_id[] = {
 	1,	0x48, // reg 0x0A
 	1,	0x3D, // reg 0x0F
 	1,	0x40, // reg 0x4F
+	1,	0x80, // reg 0x00
 	1,	0x06, // reg 0x20
 	2,	0x0A,0x30, // reg 0x2F
 	2,	0x10,0x11, // reg 0x39
@@ -228,6 +234,7 @@ const int i2c_dev_mag[] = {
 	MAG_BMM150,
 	MAG_BMM350,
 	MAG_IST8306, MAG_IST8320, MAG_IST8321,
+	MAG_QMC5883P,
 	MAG_QMC6310,
 	MAG_LIS3MDL,
 	MAG_HMC5883L,

--- a/src/sensor/sensors_enum.h
+++ b/src/sensor/sensors_enum.h
@@ -133,6 +133,7 @@ enum dev_imu {
 enum dev_mag {
 	MAG_HMC5883L,
 	MAG_QMC5883L,
+	MAG_QMC5883P,
 	MAG_QMC6309,
 	MAG_QMC6310,
 	MAG_AK8963,


### PR DESCRIPTION
This adds support for the QMC5883P, as well as the WHOAMI, as per my own research and the datasheet.
Sadly, I needed to modify the scan code to special case it, as it wasn't always detected when using it over the secondary I2C data lines of a IMU. It will sometimes work without it, but it isn't 100% reliable, so I feel it's better to have done so.

See the datasheet: https://www.qstcorp.com/upload/pdf/202202/%EF%BC%88%E5%B7%B2%E4%BC%A0%EF%BC%8913-52-19%20QMC5883P%20Datasheet%20Rev.C(1).pdf

I ended up modifying the BMI270 to clearly have the name, for clarity. I know this project does not support other BMI chips, but my personal fork may end up doing so. (even though a PR will never be made, so no one has to maintain it). If needed, I can revert it, but I see no harm.

The other thing I did was remove some miscellaneous whitespaces in some of the calibration and scan code.

From my previous PR, with more comments for clarity on why certain things were done.