### PR TITLE
calibration: clear mag-cal request when already calibrated

### DIFF
--- a/src/sensor/calibration.c
+++ b/src/sensor/calibration.c
@@ -459,7 +459,7 @@ static int sensor_calibrate_mag(void)
 {
 	float zero[3] = {0};
 	if (v_diff_mag(magBAinv[0], zero) != 0)
-		return -1; // magnetometer calibration already exists
+		return 0; // magnetometer calibration already exists
 
 	float m[3];
 	if (sensor_wait_mag(m, K_MSEC(1000)))


### PR DESCRIPTION
sensor_calibrate_mag returned early when a calibration already exists without clearing the request bit, so calibration_thread re-invoked it every 5ms forever instead of suspending. Reset the magneto state before returning. Recalibration is unaffected since clearing the mag calibration zeroes magBAinv, which lets the next request pass the guard.