### PR TITLE
Toolchain/ICM45686 SPI I2CM/QMC6309 bugfixes

### DIFF
--- a/boards/nordic/promicro_uf2/promicro_uf2.dts
+++ b/boards/nordic/promicro_uf2/promicro_uf2.dts
@@ -107,7 +107,7 @@
 	battery-divider {
 		compatible = "voltage-divider";
 		status = "okay";
-		io-channels = <&adc 12>; // Measure VDDHDIV5
+		io-channels = <&adc NRF_SAADC_VDDHDIV5>; // Measure VDDHDIV5
 		output-ohms = <1>;
 		full-ohms = <5>;
 	};

--- a/src/console.c
+++ b/src/console.c
@@ -44,10 +44,6 @@ K_THREAD_DEFINE(console_thread_id, 1024, console_thread, NULL, NULL, NULL, CONSO
 static const struct device *gpio_dev = DEVICE_DT_GET(DT_NODELABEL(gpio0));
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(mag), okay)
-#define SENSOR_MAG_EXISTS true
-#endif
-
 static const char *meows[] = {
 	"Mew",
 	"Meww",

--- a/src/sensor/calibration.c
+++ b/src/sensor/calibration.c
@@ -235,13 +235,13 @@ void sensor_calibration_clear_mag(float m_inv[][3], bool write)
 
 void sensor_request_calibration(void)
 {
-	if (sensor_calibration_request(1))
+	if (sensor_calibration_request(1) == 0)
 		k_thread_resume(calibration_thread_id);
 }
 
 void sensor_request_calibration_6_side(void)
 {
-	if (sensor_calibration_request(2))
+	if (sensor_calibration_request(2) == 0)
 		k_thread_resume(calibration_thread_id);
 }
 

--- a/src/sensor/imu/BMI270.c
+++ b/src/sensor/imu/BMI270.c
@@ -166,7 +166,7 @@ int bmi_update_odr(float accel_time, float gyro_time, float *accel_actual_time, 
 }
 
 // TODO: gyro rotation data is delayed for some reason, accelerometer still responds instantly
-uint16_t bmi_fifo_read(uint8_t *data, uint16_t len)
+uint16_t bmi_data_read(uint8_t *data, uint16_t len)
 {
 	int err = 0;
 	uint16_t total = 0;
@@ -200,7 +200,7 @@ static const uint8_t overread[2] = {0x00, 0x80};
 static const uint8_t invalid_accel[6] = {0x01, 0x7F, 0x00, 0x80, 0x00, 0x80};
 static const uint8_t invalid_gyro[6] = {0x02, 0x7F, 0x00, 0x80, 0x00, 0x80};
 
-int bmi_fifo_process(uint16_t index, uint8_t *data, float a[3], float g[3])
+int bmi_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
 {
 	index *= PACKET_SIZE;
 	if (!memcmp(&data[index], overread, sizeof(overread)))
@@ -482,8 +482,8 @@ const sensor_imu_t sensor_imu_bmi270 = {
 	*bmi_update_fs,
 	*bmi_update_odr,
 
-	*bmi_fifo_read,
-	*bmi_fifo_process,
+	*bmi_data_read,
+	*bmi_data_process,
 	*bmi_accel_read,
 	*bmi_gyro_read,
 	*bmi_temp_read,

--- a/src/sensor/imu/BMI270.c
+++ b/src/sensor/imu/BMI270.c
@@ -491,6 +491,5 @@ const sensor_imu_t sensor_imu_bmi270 = {
 	*bmi_setup_DRDY,
 	*bmi_setup_WOM,
 
-	*imu_none_ext_setup,
-	*imu_none_ext_passthrough
+	*imu_none_ext_setup
 };

--- a/src/sensor/imu/BMI270.c
+++ b/src/sensor/imu/BMI270.c
@@ -64,6 +64,8 @@ void bmi_shutdown(void) // this does not reset the device, to avoid clearing the
 	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, BMI270_PWR_CONF, 0x01); // enable adv_power_save (suspend)
 	if (err)
 		LOG_ERR("Communication error");
+	// TODO : Correctly wait for the reset to finish
+	k_msleep(1);
 }
 
 void bmi_update_fs(float accel_range, float gyro_range, float *accel_actual_range, float *gyro_actual_range)

--- a/src/sensor/imu/BMI270.c
+++ b/src/sensor/imu/BMI270.c
@@ -200,11 +200,13 @@ static const uint8_t overread[2] = {0x00, 0x80};
 static const uint8_t invalid_accel[6] = {0x01, 0x7F, 0x00, 0x80, 0x00, 0x80};
 static const uint8_t invalid_gyro[6] = {0x02, 0x7F, 0x00, 0x80, 0x00, 0x80};
 
-int bmi_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
+sensor_data_attrs_t bmi_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
 {
 	index *= PACKET_SIZE;
 	if (!memcmp(&data[index], overread, sizeof(overread)))
-		return 1; // Skip overread packets
+		return DATA_INVALID; // Skip overread packets
+
+	sensor_data_attrs_t result = 0;
 	float a_bmi[3];
 	float g_bmi[3];
 	for (int i = 0; i < 3; i++) // x, y, z
@@ -219,6 +221,7 @@ int bmi_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], floa
 		a[0] = -a_bmi[1];
 		a[1] = a_bmi[0];
 		a[2] = a_bmi[2];
+		result |= DATA_VALID_ACCEL;
 	}
 	if (memcmp(&data[index], invalid_gyro, sizeof(invalid_gyro))) // valid gyro data
 	{
@@ -227,8 +230,9 @@ int bmi_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], floa
 		g[0] = -g_bmi[1];
 		g[1] = g_bmi[0];
 		g[2] = g_bmi[2];
+		result |= DATA_VALID_GYRO;
 	}
-	return 0;
+	return result;
 }
 
 void bmi_accel_read(float a[3])

--- a/src/sensor/imu/BMI270.h
+++ b/src/sensor/imu/BMI270.h
@@ -81,8 +81,8 @@ void bmi_shutdown(void);
 void bmi_update_fs(float accel_range, float gyro_range, float *accel_actual_range, float *gyro_actual_range);
 int bmi_update_odr(float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time);
 
-uint16_t bmi_fifo_read(uint8_t *data, uint16_t len);
-int bmi_fifo_process(uint16_t index, uint8_t *data, float a[3], float g[3]);
+uint16_t bmi_data_read(uint8_t *data, uint16_t len);
+int bmi_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3]);
 void bmi_accel_read(float a[3]);
 void bmi_gyro_read(float g[3]);
 int bmi_temp_read(float *data);

--- a/src/sensor/imu/BMI270.h
+++ b/src/sensor/imu/BMI270.h
@@ -82,7 +82,7 @@ void bmi_update_fs(float accel_range, float gyro_range, float *accel_actual_rang
 int bmi_update_odr(float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time);
 
 uint16_t bmi_data_read(uint8_t *data, uint16_t len);
-int bmi_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3]);
+sensor_data_attrs_t bmi_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3]);
 void bmi_accel_read(float a[3]);
 void bmi_gyro_read(float g[3]);
 int bmi_temp_read(float *data);

--- a/src/sensor/imu/ICM42688.c
+++ b/src/sensor/imu/ICM42688.c
@@ -77,9 +77,11 @@ void icm_shutdown(void)
 {
 	last_accel_odr = 0xff; // reset last odr
 	last_gyro_odr = 0xff; // reset last odr
-	int err = ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM42688_DEVICE_CONFIG, 0x01); // Don't need to wait for ICM to finish reset
+	int err = ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM42688_DEVICE_CONFIG, 0x01);
 	if (err)
 		LOG_ERR("Communication error");
+	// TODO : Correctly wait for the reset to finish
+	k_msleep(1);
 }
 
 void icm_update_fs(float accel_range, float gyro_range, float *accel_actual_range, float *gyro_actual_range)

--- a/src/sensor/imu/ICM42688.c
+++ b/src/sensor/imu/ICM42688.c
@@ -183,7 +183,7 @@ int icm_update_odr(float accel_time, float gyro_time, float *accel_actual_time, 
 	return 0;
 }
 
-uint16_t icm_fifo_read(uint8_t *data, uint16_t len)
+uint16_t icm_data_read(uint8_t *data, uint16_t len)
 {
 	int err = 0;
 	uint16_t total = 0;
@@ -217,7 +217,7 @@ uint16_t icm_fifo_read(uint8_t *data, uint16_t len)
 
 static const uint8_t invalid[6] = {0x80, 0x00, 0x80, 0x00, 0x80, 0x00};
 
-int icm_fifo_process(uint16_t index, uint8_t *data, float a[3], float g[3])
+int icm_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
 {
 	index *= PACKET_SIZE;
 	if ((data[index] & 0x80) == 0x80)
@@ -335,8 +335,8 @@ const sensor_imu_t sensor_imu_icm42688 = {
 	*icm_update_fs,
 	*icm_update_odr,
 
-	*icm_fifo_read,
-	*icm_fifo_process,
+	*icm_data_read,
+	*icm_data_process,
 	*icm_accel_read,
 	*icm_gyro_read,
 	*icm_temp_read,

--- a/src/sensor/imu/ICM42688.c
+++ b/src/sensor/imu/ICM42688.c
@@ -344,6 +344,5 @@ const sensor_imu_t sensor_imu_icm42688 = {
 	*icm_setup_DRDY,
 	*icm_setup_WOM,
 
-	*imu_none_ext_setup,
-	*imu_none_ext_passthrough
+	*imu_none_ext_setup
 };

--- a/src/sensor/imu/ICM42688.c
+++ b/src/sensor/imu/ICM42688.c
@@ -217,38 +217,41 @@ uint16_t icm_data_read(uint8_t *data, uint16_t len)
 
 static const uint8_t invalid[6] = {0x80, 0x00, 0x80, 0x00, 0x80, 0x00};
 
-int icm_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
+sensor_data_attrs_t icm_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
 {
 	index *= PACKET_SIZE;
 	if ((data[index] & 0x80) == 0x80)
-		return 1; // Skip empty packets
+		return DATA_INVALID; // Skip empty packets
 	if ((data[index] & 0x7F) == 0x7F)
-		return 1; // Skip empty packets
+		return DATA_INVALID; // Skip empty packets
+
+	sensor_data_attrs_t result = 0;
+
 	// combine into 20 bit values in 32 bit int
-	float a_raw[3] = {0};
-	float g_raw[3] = {0};
 	if (memcmp(&data[index + 1], invalid, sizeof(invalid))) // valid accel data
 	{
 		for (int i = 0; i < 3; i++) // accel x, y, z
-			a_raw[i] = (int32_t)((((uint32_t)data[index + 1 + (i * 2)]) << 24) | (((uint32_t)data[index + 2 + (i * 2)]) << 16) | (((uint32_t)data[index + 17 + i] & 0xF0) << 8));
+			a[i] = (int32_t)((((uint32_t)data[index + 1 + (i * 2)]) << 24) | (((uint32_t)data[index + 2 + (i * 2)]) << 16) | (((uint32_t)data[index + 17 + i] & 0xF0) << 8));
+
+		result |= DATA_VALID_ACCEL;
 	}
 	if (memcmp(&data[index + 7], invalid, sizeof(invalid))) // valid gyro data
 	{
 		for (int i = 0; i < 3; i++) // gyro x, y, z
-			g_raw[i] = (int32_t)((((uint32_t)data[index + 7 + (i * 2)]) << 24) | (((uint32_t)data[index + 8 + (i * 2)]) << 16) | (((uint32_t)data[index + 17 + i] & 0x0F) << 12));
+			g[i] = (int32_t)((((uint32_t)data[index + 7 + (i * 2)]) << 24) | (((uint32_t)data[index + 8 + (i * 2)]) << 16) | (((uint32_t)data[index + 17 + i] & 0x0F) << 12));
+		
+		result |= DATA_VALID_GYRO;
 	}
 	else if (!memcmp(&data[index + 1], invalid, sizeof(invalid))) // Skip invalid data
 	{
-		return 1;
+		return DATA_INVALID;
 	}
 	for (int i = 0; i < 3; i++) // x, y, z
 	{
-		a_raw[i] *= accel_sensitivity_32;
-		g_raw[i] *= gyro_sensitivity_32;
+		a[i] *= accel_sensitivity_32;
+		g[i] *= gyro_sensitivity_32;
 	}
-	memcpy(a, a_raw, sizeof(a_raw));
-	memcpy(g, g_raw, sizeof(g_raw));
-	return 0;
+	return result;
 }
 
 void icm_accel_read(float a[3])

--- a/src/sensor/imu/ICM42688.h
+++ b/src/sensor/imu/ICM42688.h
@@ -116,8 +116,8 @@ void icm_shutdown(void);
 void icm_update_fs(float accel_range, float gyro_range, float *accel_actual_range, float *gyro_actual_range);
 int icm_update_odr(float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time);
 
-uint16_t icm_fifo_read(uint8_t *data, uint16_t len);
-int icm_fifo_process(uint16_t index, uint8_t *data, float a[3], float g[3]);
+uint16_t icm_data_read(uint8_t *data, uint16_t len);
+int icm_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3]);
 void icm_accel_read(float a[3]);
 void icm_gyro_read(float g[3]);
 int icm_temp_read(float *data);

--- a/src/sensor/imu/ICM42688.h
+++ b/src/sensor/imu/ICM42688.h
@@ -117,7 +117,7 @@ void icm_update_fs(float accel_range, float gyro_range, float *accel_actual_rang
 int icm_update_odr(float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time);
 
 uint16_t icm_data_read(uint8_t *data, uint16_t len);
-int icm_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3]);
+sensor_data_attrs_t icm_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3]);
 void icm_accel_read(float a[3]);
 void icm_gyro_read(float g[3]);
 int icm_temp_read(float *data);

--- a/src/sensor/imu/ICM45686.c
+++ b/src/sensor/imu/ICM45686.c
@@ -349,6 +349,148 @@ int icm45_ext_passthrough(bool passthrough)
 	return 0;
 }
 
+int icm45_ext_setup() {
+  int err = 0;
+  err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IOC_PAD_SCENARIO_AUX_OVRD, 0x17); // AUX1_MODE_OVRD, AUX1 in I2CM Master, AUX1_ENABLE_OVRD, AUX1 enabled
+  sensor_interface_ext_configure(&sensor_ext_icm45686);
+  return err;
+}
+
+int icm45_bank_write(const uint8_t bank, const uint8_t reg, const uint8_t *buf, uint32_t num_bytes)
+{
+  if (num_bytes == 0)
+  {
+    LOG_ERR("Invalid bank write size");
+    return -1;
+  }
+
+  int err = 0;
+  uint8_t ireg_buf[3];
+  ireg_buf[0] = bank;
+  ireg_buf[1] = reg;
+  ireg_buf[2] = buf[0];
+  err |= ssi_burst_write(SENSOR_INTERFACE_DEV_IMU, ICM45686_IREG_ADDR_15_8, ireg_buf, 3);
+  k_usleep(4);
+
+  for (uint32_t i = 1; i < num_bytes; i++) 
+  {
+    err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IREG_DATA, buf[i]);
+    k_usleep(4);
+  }
+
+  return err;
+}
+
+int icm45_bank_write_byte(const uint8_t bank, const uint8_t reg, const uint8_t value)
+{
+  return icm45_bank_write(bank, reg, &value, 1);
+}
+
+int icm45_bank_read(const uint8_t bank, const uint8_t reg, uint8_t *buf, uint32_t num_bytes) 
+{
+  if (num_bytes == 0)
+  {
+    LOG_ERR("Invalid bank read size");
+    return -1;
+  }
+
+  int err = 0;
+  uint8_t ireg_buf[2];
+  ireg_buf[0] = bank;
+  ireg_buf[1] = reg;
+  err |= ssi_burst_write(SENSOR_INTERFACE_DEV_IMU, ICM45686_IREG_ADDR_15_8, ireg_buf, 2);
+  k_usleep(4);
+
+  for (uint32_t i = 0; i < num_bytes; i++) 
+  {
+    err |= ssi_reg_read_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IREG_DATA, &buf[i]);
+    k_usleep(4);
+  }
+  return err;
+}
+
+int icm45_bank_read_byte(const uint8_t bank, const uint8_t reg, uint8_t *value) {
+  return icm45_bank_read(bank, reg, value, 1);
+}
+
+int icm45_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes) 
+{
+  if (num_bytes > 6) 
+  {
+    LOG_ERR("Unsupported write");
+    return -1;
+  }
+
+  int err = 0;
+
+  err |= icm45_bank_write(ICM45686_IPREG_TOP1, ICM45686_I2CM_WR_DATA_0, buf, num_bytes);
+  err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_COMMAND_0, 0x80 + num_bytes); // Last transaction, channel 0, write num_bytes bytes
+  err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_CONTROL, 0x01); // No restarts, fast mode, start transaction
+
+  uint8_t last_status = 0;
+  err |= icm45_bank_read_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_STATUS, &last_status);
+  while (last_status & 0x01) // I2CM busy
+  {
+    err |= icm45_bank_read_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_STATUS, &last_status);
+  }
+
+  if (last_status != 0x02) // Not (just) "done"
+  {
+    LOG_ERR("I2CM error: %02x", last_status);
+    return -1;
+  }
+
+  uint8_t dev_status;
+  err |= icm45_bank_read_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_EXT_DEV_STATUS, &dev_status);
+
+  if (dev_status & 0x01) {
+    // Maybe log the nack?
+    return -1;
+  }
+
+  return err;
+}
+
+int icm45_ext_write_read(const uint8_t addr, const void *write_buf, size_t num_write, void *read_buf, size_t num_read) {
+  if (num_write != 1 || num_read < 1 || num_read > 15) 
+  {
+    LOG_ERR("Unsupported write_read");
+    return -1;
+  }
+
+  int err = 0;
+
+  uint8_t dev_profile_data[2] = {((const uint8_t *)write_buf)[0], addr};
+  err |= icm45_bank_write(ICM45686_IPREG_TOP1, ICM45686_DEV_PROFILE_0, dev_profile_data, 2);
+  err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_COMMAND_0, 0x90 + num_read); // Last transaction, channel 0, read num_read bytes with register specified
+  err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_CONTROL, 0x01); // No restarts, fast mode, start transaction
+
+  uint8_t last_status = 0;
+  err |= icm45_bank_read_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_STATUS, &last_status);
+  while (last_status & 0x01) // I2CM busy
+  {
+    err |= icm45_bank_read_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_STATUS, &last_status);
+  }
+
+  if (last_status != 0x02) // Not (just) "done"
+  {
+    LOG_ERR("I2CM error: %02x", last_status);
+    return -1;
+  }
+
+  uint8_t dev_status;
+  err |= icm45_bank_read_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_EXT_DEV_STATUS, &dev_status);
+
+  if (dev_status & 0x01) {
+    // Maybe log the nack?
+    return -1;
+  }
+
+  err |= icm45_bank_read(ICM45686_IPREG_TOP1, ICM45686_I2CM_RD_DATA_0, read_buf, num_read);
+
+  return err;
+}
+
 const sensor_imu_t sensor_imu_icm45686 = {
 	*icm45_init,
 	*icm45_shutdown,
@@ -365,6 +507,12 @@ const sensor_imu_t sensor_imu_icm45686 = {
 	*icm45_setup_DRDY,
 	*icm45_setup_WOM,
 
-	*imu_none_ext_setup,
+	*icm45_ext_setup,
 	*icm45_ext_passthrough
+};
+
+const sensor_ext_ssi_t sensor_ext_icm45686 = {
+  *icm45_ext_write,
+  *icm45_ext_write_read,
+  15
 };

--- a/src/sensor/imu/ICM45686.c
+++ b/src/sensor/imu/ICM45686.c
@@ -350,145 +350,145 @@ int icm45_ext_passthrough(bool passthrough)
 }
 
 int icm45_ext_setup() {
-  int err = 0;
-  err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IOC_PAD_SCENARIO_AUX_OVRD, 0x17); // AUX1_MODE_OVRD, AUX1 in I2CM Master, AUX1_ENABLE_OVRD, AUX1 enabled
-  sensor_interface_ext_configure(&sensor_ext_icm45686);
-  return err;
+	int err = 0;
+	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IOC_PAD_SCENARIO_AUX_OVRD, 0x17); // AUX1_MODE_OVRD, AUX1 in I2CM Master, AUX1_ENABLE_OVRD, AUX1 enabled
+	sensor_interface_ext_configure(&sensor_ext_icm45686);
+	return err;
 }
 
 int icm45_bank_write(const uint8_t bank, const uint8_t reg, const uint8_t *buf, uint32_t num_bytes)
 {
-  if (num_bytes == 0)
-  {
-    LOG_ERR("Invalid bank write size");
-    return -1;
-  }
+	if (num_bytes == 0)
+	{
+		LOG_ERR("Invalid bank write size");
+		return -1;
+	}
 
-  int err = 0;
-  uint8_t ireg_buf[3];
-  ireg_buf[0] = bank;
-  ireg_buf[1] = reg;
-  ireg_buf[2] = buf[0];
-  err |= ssi_burst_write(SENSOR_INTERFACE_DEV_IMU, ICM45686_IREG_ADDR_15_8, ireg_buf, 3);
-  k_usleep(4);
+	int err = 0;
+	uint8_t ireg_buf[3];
+	ireg_buf[0] = bank;
+	ireg_buf[1] = reg;
+	ireg_buf[2] = buf[0];
+	err |= ssi_burst_write(SENSOR_INTERFACE_DEV_IMU, ICM45686_IREG_ADDR_15_8, ireg_buf, 3);
+	k_usleep(4);
 
-  for (uint32_t i = 1; i < num_bytes; i++) 
-  {
-    err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IREG_DATA, buf[i]);
-    k_usleep(4);
-  }
+	for (uint32_t i = 1; i < num_bytes; i++)
+	{
+		err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IREG_DATA, buf[i]);
+		k_usleep(4);
+	}
 
-  return err;
+	return err;
 }
 
 int icm45_bank_write_byte(const uint8_t bank, const uint8_t reg, const uint8_t value)
 {
-  return icm45_bank_write(bank, reg, &value, 1);
+	return icm45_bank_write(bank, reg, &value, 1);
 }
 
-int icm45_bank_read(const uint8_t bank, const uint8_t reg, uint8_t *buf, uint32_t num_bytes) 
+int icm45_bank_read(const uint8_t bank, const uint8_t reg, uint8_t *buf, uint32_t num_bytes)
 {
-  if (num_bytes == 0)
-  {
-    LOG_ERR("Invalid bank read size");
-    return -1;
-  }
+	if (num_bytes == 0)
+	{
+		LOG_ERR("Invalid bank read size");
+		return -1;
+	}
 
-  int err = 0;
-  uint8_t ireg_buf[2];
-  ireg_buf[0] = bank;
-  ireg_buf[1] = reg;
-  err |= ssi_burst_write(SENSOR_INTERFACE_DEV_IMU, ICM45686_IREG_ADDR_15_8, ireg_buf, 2);
-  k_usleep(4);
+	int err = 0;
+	uint8_t ireg_buf[2];
+	ireg_buf[0] = bank;
+	ireg_buf[1] = reg;
+	err |= ssi_burst_write(SENSOR_INTERFACE_DEV_IMU, ICM45686_IREG_ADDR_15_8, ireg_buf, 2);
+	k_usleep(4);
 
-  for (uint32_t i = 0; i < num_bytes; i++) 
-  {
-    err |= ssi_reg_read_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IREG_DATA, &buf[i]);
-    k_usleep(4);
-  }
-  return err;
+	for (uint32_t i = 0; i < num_bytes; i++)
+	{
+		err |= ssi_reg_read_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IREG_DATA, &buf[i]);
+		k_usleep(4);
+	}
+	return err;
 }
 
 int icm45_bank_read_byte(const uint8_t bank, const uint8_t reg, uint8_t *value) {
-  return icm45_bank_read(bank, reg, value, 1);
+	return icm45_bank_read(bank, reg, value, 1);
 }
 
 int icm45_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes) 
 {
-  if (num_bytes > 6) 
-  {
-    LOG_ERR("Unsupported write");
-    return -1;
-  }
+	if (num_bytes > 6) 
+	{
+		LOG_ERR("Unsupported write");
+		return -1;
+	}
 
-  int err = 0;
+	int err = 0;
 
-  err |= icm45_bank_write(ICM45686_IPREG_TOP1, ICM45686_I2CM_WR_DATA_0, buf, num_bytes);
-  err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_COMMAND_0, 0x80 + num_bytes); // Last transaction, channel 0, write num_bytes bytes
-  err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_CONTROL, 0x01); // No restarts, fast mode, start transaction
+	err |= icm45_bank_write(ICM45686_IPREG_TOP1, ICM45686_I2CM_WR_DATA_0, buf, num_bytes);
+	err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_COMMAND_0, 0x80 + num_bytes); // Last transaction, channel 0, write num_bytes bytes
+	err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_CONTROL, 0x01); // No restarts, fast mode, start transaction
 
-  uint8_t last_status = 0;
-  err |= icm45_bank_read_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_STATUS, &last_status);
-  while (last_status & 0x01) // I2CM busy
-  {
-    err |= icm45_bank_read_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_STATUS, &last_status);
-  }
+	uint8_t last_status = 0;
+	err |= icm45_bank_read_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_STATUS, &last_status);
+	while (last_status & 0x01) // I2CM busy
+	{
+		err |= icm45_bank_read_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_STATUS, &last_status);
+	}
 
-  if (last_status != 0x02) // Not (just) "done"
-  {
-    LOG_ERR("I2CM error: %02x", last_status);
-    return -1;
-  }
+	if (last_status != 0x02) // Not (just) "done"
+	{
+		LOG_ERR("I2CM error: %02x", last_status);
+		return -1;
+	}
 
-  uint8_t dev_status;
-  err |= icm45_bank_read_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_EXT_DEV_STATUS, &dev_status);
+	uint8_t dev_status;
+	err |= icm45_bank_read_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_EXT_DEV_STATUS, &dev_status);
 
-  if (dev_status & 0x01) {
-    // Maybe log the nack?
-    return -1;
-  }
+	if (dev_status & 0x01) {
+		// Maybe log the nack?
+		return -1;
+	}
 
-  return err;
+	return err;
 }
 
 int icm45_ext_write_read(const uint8_t addr, const void *write_buf, size_t num_write, void *read_buf, size_t num_read) {
-  if (num_write != 1 || num_read < 1 || num_read > 15) 
-  {
-    LOG_ERR("Unsupported write_read");
-    return -1;
-  }
+	if (num_write != 1 || num_read < 1 || num_read > 15)
+	{
+		LOG_ERR("Unsupported write_read");
+		return -1;
+	}
 
-  int err = 0;
+	int err = 0;
 
-  uint8_t dev_profile_data[2] = {((const uint8_t *)write_buf)[0], addr};
-  err |= icm45_bank_write(ICM45686_IPREG_TOP1, ICM45686_DEV_PROFILE_0, dev_profile_data, 2);
-  err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_COMMAND_0, 0x90 + num_read); // Last transaction, channel 0, read num_read bytes with register specified
-  err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_CONTROL, 0x01); // No restarts, fast mode, start transaction
+	uint8_t dev_profile_data[2] = {((const uint8_t *)write_buf)[0], addr};
+	err |= icm45_bank_write(ICM45686_IPREG_TOP1, ICM45686_DEV_PROFILE_0, dev_profile_data, 2);
+	err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_COMMAND_0, 0x90 + num_read); // Last transaction, channel 0, read num_read bytes with register specified
+	err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_CONTROL, 0x01); // No restarts, fast mode, start transaction
 
-  uint8_t last_status = 0;
-  err |= icm45_bank_read_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_STATUS, &last_status);
-  while (last_status & 0x01) // I2CM busy
-  {
-    err |= icm45_bank_read_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_STATUS, &last_status);
-  }
+	uint8_t last_status = 0;
+	err |= icm45_bank_read_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_STATUS, &last_status);
+	while (last_status & 0x01) // I2CM busy
+	{
+		err |= icm45_bank_read_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_STATUS, &last_status);
+	}
 
-  if (last_status != 0x02) // Not (just) "done"
-  {
-    LOG_ERR("I2CM error: %02x", last_status);
-    return -1;
-  }
+	if (last_status != 0x02) // Not (just) "done"
+	{
+		LOG_ERR("I2CM error: %02x", last_status);
+		return -1;
+	}
 
-  uint8_t dev_status;
-  err |= icm45_bank_read_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_EXT_DEV_STATUS, &dev_status);
+	uint8_t dev_status;
+	err |= icm45_bank_read_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_EXT_DEV_STATUS, &dev_status);
 
-  if (dev_status & 0x01) {
-    // Maybe log the nack?
-    return -1;
-  }
+	if (dev_status & 0x01) {
+		// Maybe log the nack?
+		return -1;
+	}
 
-  err |= icm45_bank_read(ICM45686_IPREG_TOP1, ICM45686_I2CM_RD_DATA_0, read_buf, num_read);
+	err |= icm45_bank_read(ICM45686_IPREG_TOP1, ICM45686_I2CM_RD_DATA_0, read_buf, num_read);
 
-  return err;
+	return err;
 }
 
 const sensor_imu_t sensor_imu_icm45686 = {
@@ -512,7 +512,7 @@ const sensor_imu_t sensor_imu_icm45686 = {
 };
 
 const sensor_ext_ssi_t sensor_ext_icm45686 = {
-  *icm45_ext_write,
-  *icm45_ext_write_read,
-  15
+	*icm45_ext_write,
+	*icm45_ext_write_read,
+	15
 };

--- a/src/sensor/imu/ICM45686.c
+++ b/src/sensor/imu/ICM45686.c
@@ -27,6 +27,8 @@ static float clock_scale = 1; // ODR is scaled by clock_rate/clock_reference
 
 static float fifo_multiplier_factor = FIFO_MULT;
 static float fifo_multiplier = 0;
+static uint8_t aux_addr = 0;
+static uint8_t aux_reg = 0;
 
 LOG_MODULE_REGISTER(ICM45686, LOG_LEVEL_DBG);
 
@@ -74,6 +76,8 @@ void icm45_shutdown(void)
 	last_accel_odr = 0xff; // reset last odr
 	last_gyro_odr = 0xff; // reset last odr
 	int err = ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_REG_MISC2, 0x02); // Don't need to wait for ICM to finish reset
+	aux_addr = 0;
+	aux_reg = 0;
 //	k_msleep(1);
 	// TODO: not working
 //	uint8_t ireg_buf[3];
@@ -413,6 +417,26 @@ int icm45_bank_read_byte(const uint8_t bank, const uint8_t reg, uint8_t *value) 
 	return icm45_bank_read(bank, reg, value, 1);
 }
 
+int icm45_aux_addr_set(const uint8_t addr, const uint8_t reg) {
+	int err = 0;
+	if (aux_addr != addr) { // aux address changed, rewrite both address and register
+		uint8_t dev_profile_data[2] = {reg, addr};
+		err = icm45_bank_write(ICM45686_IPREG_TOP1, ICM45686_DEV_PROFILE_0, dev_profile_data, sizeof(dev_profile_data));
+		if (!err) {
+			aux_addr = addr;
+			aux_reg = reg;
+		}
+	}
+	else if (aux_reg != reg) { // only register changed, aux address remains
+		err = icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_DEV_PROFILE_0, reg);
+		if (!err) {
+			aux_reg = reg;
+		}
+	}
+
+	return err;
+}
+
 int icm45_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes) 
 {
 	if (num_bytes > 6) 
@@ -421,7 +445,7 @@ int icm45_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes)
 		return -1;
 	}
 
-	int err = 0;
+	int err = icm45_aux_addr_set(addr, aux_reg);
 
 	err |= icm45_bank_write(ICM45686_IPREG_TOP1, ICM45686_I2CM_WR_DATA_0, buf, num_bytes);
 	err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_COMMAND_0, 0x80 + num_bytes); // Last transaction, channel 0, write num_bytes bytes
@@ -451,17 +475,15 @@ int icm45_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes)
 	return err;
 }
 
-int icm45_ext_write_read(const uint8_t addr, const void *write_buf, size_t num_write, void *read_buf, size_t num_read) {
+int icm45_ext_write_read(const uint8_t addr, const uint8_t *write_buf, size_t num_write, uint8_t *read_buf, size_t num_read) {
 	if (num_write != 1 || num_read < 1 || num_read > 15)
 	{
 		LOG_ERR("Unsupported write_read");
 		return -1;
 	}
 
-	int err = 0;
+	int err = icm45_aux_addr_set(addr, write_buf[0]);
 
-	uint8_t dev_profile_data[2] = {((const uint8_t *)write_buf)[0], addr};
-	err |= icm45_bank_write(ICM45686_IPREG_TOP1, ICM45686_DEV_PROFILE_0, dev_profile_data, 2);
 	err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_COMMAND_0, 0x90 + num_read); // Last transaction, channel 0, read num_read bytes with register specified
 	err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_CONTROL, 0x01); // No restarts, fast mode, start transaction
 

--- a/src/sensor/imu/ICM45686.c
+++ b/src/sensor/imu/ICM45686.c
@@ -27,8 +27,10 @@ static float clock_scale = 1; // ODR is scaled by clock_rate/clock_reference
 
 static float fifo_multiplier_factor = FIFO_MULT;
 static float fifo_multiplier = 0;
-static uint8_t aux_addr = 0;
-static uint8_t aux_reg = 0;
+static uint8_t ext_mode = SENSOR_EXT_MODE_OFF;
+static uint8_t ext_addr = 0;
+static uint8_t ext_reg = 0;
+static const sensor_mag_t *ext_mag = NULL;
 
 LOG_MODULE_REGISTER(ICM45686, LOG_LEVEL_DBG);
 
@@ -78,8 +80,10 @@ void icm45_shutdown(void)
 	last_accel_odr = 0xff; // reset last odr
 	last_gyro_odr = 0xff; // reset last odr
 	int err = ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_REG_MISC2, 0x02);
-	aux_addr = 0;
-	aux_reg = 0;
+	ext_mode = SENSOR_EXT_MODE_OFF;
+	ext_addr = 0;
+	ext_reg = 0;
+
 //	uint8_t ireg_buf[3];
 //	ireg_buf[1] = ICM45686_IPREG_BAR_REG_60;
 //	ireg_buf[2] = 0x6D & ~0x05; // set internal pull down resistors for AP pins (pin 10, 7)
@@ -205,73 +209,6 @@ int icm45_update_odr(float accel_time, float gyro_time, float *accel_actual_time
 	return 0;
 }
 
-uint16_t icm45_fifo_read(uint8_t *data, uint16_t len) // TODO: check if working
-{
-	int err = 0;
-	uint16_t total = 0;
-	uint16_t packets = UINT16_MAX;
-	while (packets > 0 && len >= PACKET_SIZE)
-	{
-		uint8_t rawCount[2];
-		err |= ssi_burst_read(SENSOR_INTERFACE_DEV_IMU, ICM45686_FIFO_COUNT_0, &rawCount[0], 2);
-		packets = (uint16_t)(rawCount[0] << 8 | rawCount[1]); // Turn the 16 bits into a unsigned 16-bit value
-		if (!packets) // nothing to do
-			break;
-		float extra_read_packets = packets * fifo_multiplier;
-		packets += extra_read_packets;
-		uint16_t count = packets * PACKET_SIZE;
-		uint16_t limit = len / PACKET_SIZE;
-		if (packets > limit)
-		{
-			LOG_WRN("FIFO read buffer limit reached, %d packets dropped", packets - limit);
-			packets = limit;
-			count = packets * PACKET_SIZE;
-		}
-		err |= ssi_burst_read_interval(SENSOR_INTERFACE_DEV_IMU, ICM45686_FIFO_DATA, data, count, PACKET_SIZE);
-		if (err)
-			LOG_ERR("Communication error");
-		data += packets * PACKET_SIZE;
-		len -= packets * PACKET_SIZE;
-		total += packets;
-	}
-	return total;
-}
-
-static const uint8_t invalid[6] = {0x80, 0x00, 0x80, 0x00, 0x80, 0x00};
-
-int icm45_fifo_process(uint16_t index, uint8_t *data, float a[3], float g[3])
-{
-	index *= PACKET_SIZE;
-	if (data[index] != 0x78) // ACCEL_EN, GYRO_EN, HIRES_EN, TMST_FIELD_EN
-		return 1; // Skip invalid header
-	// Empty packet is 7F filled
-	// combine into 20 bit values in 32 bit int
-	float a_raw[3] = {0};
-	float g_raw[3] = {0};
-	if (memcmp(&data[index + 1], invalid, sizeof(invalid))) // valid accel data
-	{
-		for (int i = 0; i < 3; i++) // accel x, y, z
-			a_raw[i] = (int32_t)((((uint32_t)data[index + 1 + (i * 2)]) << 24) | (((uint32_t)data[index + 2 + (i * 2)]) << 16) | (((uint32_t)data[index + 17 + i] & 0xF0) << 8));
-	}
-	if (memcmp(&data[index + 7], invalid, sizeof(invalid))) // valid gyro data
-	{
-		for (int i = 0; i < 3; i++) // gyro x, y, z
-			g_raw[i] = (int32_t)((((uint32_t)data[index + 7 + (i * 2)]) << 24) | (((uint32_t)data[index + 8 + (i * 2)]) << 16) | (((uint32_t)data[index + 17 + i] & 0x0F) << 12));
-	}
-	else if (!memcmp(&data[index + 1], invalid, sizeof(invalid))) // Skip invalid data
-	{
-		return 1;
-	}
-	for (int i = 0; i < 3; i++) // x, y, z
-	{
-		a_raw[i] *= accel_sensitivity_32;
-		g_raw[i] *= gyro_sensitivity_32;
-	}
-	memcpy(a, a_raw, sizeof(a_raw));
-	memcpy(g, g_raw, sizeof(g_raw));
-	return 0;
-}
-
 void icm45_accel_read(float a[3])
 {
 	uint8_t rawAccel[6];
@@ -350,37 +287,10 @@ uint8_t icm45_setup_WOM(void) // TODO: check if working
 	ireg_buf[4] = 0x08; // set wake thresholds
 	err |= ssi_burst_write(SENSOR_INTERFACE_DEV_IMU, ICM45686_IREG_ADDR_15_8, ireg_buf, 5); // write buffer
 	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_TMST_WOM_CONFIG, 0x14); // enable WOM, enable WOM interrupt
-	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_INT1_CONFIG1, 0x0E); // route WOM interrupt
+	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_INT1_CONFIG1, INT1_STATUS_WOM_X | INT1_STATUS_WOM_Y | INT1_STATUS_WOM_Z);
 	if (err)
 		LOG_ERR("Communication error");
 	return NRF_GPIO_PIN_PULLUP << 4 | NRF_GPIO_PIN_SENSE_LOW; // active low
-}
-
-int icm45_ext_setup(enum sensor_ext_mode mode) {
-	int err = 0;
-	switch (mode) {
-		case SENSOR_EXT_MODE_OFF:
-			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IOC_PAD_SCENARIO_AUX_OVRD, 0x00); // disable overrides
-			break;
-
-		case SENSOR_EXT_MODE_I2C_PASSTHROUGH:
-			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IOC_PAD_SCENARIO_AUX_OVRD, 0x18); // AUX1_MODE_OVRD, AUX1 in I2CM Bypass
-			break;
-			
-		case SENSOR_EXT_MODE_I2CM_PROXY:
-			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IOC_PAD_SCENARIO_AUX_OVRD, 0x17); // AUX1_MODE_OVRD, AUX1 in I2CM Master, AUX1_ENABLE_OVRD, AUX1 enabled
-			sensor_interface_ext_configure(&sensor_ext_icm45686);
-			break;
-		
-		case SENSOR_EXT_MODE_I2CM_AUTONOMOUS:
-			return -1;
-	}
-
-	if (err) {
-		LOG_ERR("Communication error: %d", err);
-	}
-
-	return err;
 }
 
 int icm45_bank_write(const uint8_t bank, const uint8_t reg, const uint8_t *buf, uint32_t num_bytes)
@@ -440,20 +350,20 @@ int icm45_bank_read_byte(const uint8_t bank, const uint8_t reg, uint8_t *value) 
 	return icm45_bank_read(bank, reg, value, 1);
 }
 
-int icm45_aux_addr_set(const uint8_t addr, const uint8_t reg) {
+int icm45_ext_addr_set(const uint8_t addr, const uint8_t reg) {
 	int err = 0;
-	if (aux_addr != addr) { // aux address changed, rewrite both address and register
+	if (ext_addr != addr) { // aux address changed, rewrite both address and register
 		uint8_t dev_profile_data[2] = {reg, addr};
 		err = icm45_bank_write(ICM45686_IPREG_TOP1, ICM45686_DEV_PROFILE_0, dev_profile_data, sizeof(dev_profile_data));
 		if (!err) {
-			aux_addr = addr;
-			aux_reg = reg;
+			ext_addr = addr;
+			ext_reg = reg;
 		}
 	}
-	else if (aux_reg != reg) { // only register changed, aux address remains
+	else if (ext_reg != reg) { // only register changed, aux address remains
 		err = icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_DEV_PROFILE_0, reg);
 		if (!err) {
-			aux_reg = reg;
+			ext_reg = reg;
 		}
 	}
 
@@ -462,13 +372,17 @@ int icm45_aux_addr_set(const uint8_t addr, const uint8_t reg) {
 
 int icm45_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes) 
 {
+	if (ext_mode != SENSOR_EXT_MODE_I2CM_PROXY) {
+		LOG_ERR("Sensor not in correct mode to perform ext write: %d", ext_mode);
+	}
+
 	if (num_bytes > 6) 
 	{
 		LOG_ERR("Unsupported write");
 		return -1;
 	}
 
-	int err = icm45_aux_addr_set(addr, aux_reg);
+	int err = icm45_ext_addr_set(addr, ext_reg);
 
 	err |= icm45_bank_write(ICM45686_IPREG_TOP1, ICM45686_I2CM_WR_DATA_0, buf, num_bytes);
 	err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_COMMAND_0, 0x80 + num_bytes); // Last transaction, channel 0, write num_bytes bytes
@@ -505,7 +419,11 @@ int icm45_ext_write_read(const uint8_t addr, const uint8_t *write_buf, size_t nu
 		return -1;
 	}
 
-	int err = icm45_aux_addr_set(addr, write_buf[0]);
+	if (ext_mode != SENSOR_EXT_MODE_I2CM_PROXY) {
+		LOG_ERR("Sensor not in correct mode to perform ext write read: %d", ext_mode);
+	}
+
+	int err = icm45_ext_addr_set(addr, write_buf[0]);
 
 	err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_COMMAND_0, 0x90 + num_read); // Last transaction, channel 0, read num_read bytes with register specified
 	err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_CONTROL, 0x01); // No restarts, fast mode, start transaction
@@ -536,6 +454,180 @@ int icm45_ext_write_read(const uint8_t addr, const uint8_t *write_buf, size_t nu
 	return err;
 }
 
+int icm45_ext_setup(enum sensor_ext_mode mode, const sensor_mag_t *mag, uint8_t mag_addr) {
+	int err = 0;
+	ext_mag = NULL; // only autonomous mode will set this 
+
+	switch (mode) {
+		case SENSOR_EXT_MODE_OFF:
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IOC_PAD_SCENARIO_AUX_OVRD, 0x01); // override AUX1_ENABLE=0
+			break;
+
+		case SENSOR_EXT_MODE_I2C_PASSTHROUGH:
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IOC_PAD_SCENARIO_AUX_OVRD, 0x1B); // AUX1_ENABLE=1 AUX1_MODE=I2CM Bypass
+			break;
+			
+		case SENSOR_EXT_MODE_I2CM_PROXY:
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IOC_PAD_SCENARIO_AUX_OVRD, 0x17); // AUX1_ENABLE=1 AUX1_MODE=I2CM
+			if (!err) {
+				sensor_interface_ext_configure(&sensor_ext_icm45686);
+			}
+			break;
+		
+		case SENSOR_EXT_MODE_I2CM_AUTONOMOUS:
+			ext_mag = mag;
+			const uint8_t total_bytes = mag->ext_burst + mag->ext_dummy_bytes;
+			if (total_bytes > 9) {
+				return -1; // not supported (for now)
+			}
+
+			// we're going to do periodic burst read of length defined by mag starting from ext_burst_reg
+			// not asking IMU to put that data info FIFO, as we would lose hi-res mode
+
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IOC_PAD_SCENARIO_AUX_OVRD, 0x17); // AUX1_ENABLE=1 AUX1_MODE=I2CM
+			err |= icm45_ext_addr_set(mag_addr, mag->ext_burst_reg);
+			// prepare transaction that will be repeated periodically
+			err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_COMMAND_0, 0x90 | total_bytes); // read operation with register address, ch 0, endflag_0=1
+			err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_I2CM_CONTROL, 0x40); // allow restarts, fast mode
+
+			// the following lines would put data in fifo, resulting in lost of hi-res mode. Also, fifo read function is not prepared for that
+			//err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_FIFO_CONFIG4, (total_bytes > 6 ? 1 : 0)); // set FIFO_ES0_6B_9B
+			//err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_FIFO_CONFIG3, 0x1f); // everything like on _init, with FIFO_ES0_EN=1
+
+			const float ext_intervals[] = {1.0f/3.125f, 1.0f/6.25f, 1.0f/12.5f, 1.0f/25, 1.0f/50, 1.0f/100, 1.0f/200, 1.0f/400};
+			const uint8_t ext_odr[] = {EXT_ODR_3_125Hz, EXT_ODR_6_25Hz, EXT_ODR_12_5Hz, EXT_ODR_25Hz, EXT_ODR_50Hz, EXT_ODR_100Hz, EXT_ODR_200Hz, EXT_ODR_400Hz};
+
+			// select odr that is just higher or equal to mag odr, we might consider higher value
+			const float mag_odr = mag->get_odr();
+			size_t sel_odr;
+
+			for (sel_odr = 0; sel_odr<sizeof(ext_intervals)/sizeof(ext_intervals[0]); sel_odr++)
+			{
+				if (ext_intervals[sel_odr] <= mag_odr) break;
+			}
+
+			// this is apparently needed https://github.com/tdk-invn-oss/motion.arduino.ICM45686/blob/main/src/ICM45686.cpp#L859
+			err |= icm45_bank_write_byte(ICM45686_IPREG_TOP1, ICM45686_INT_I2CM_SOURCE, INT_STATUS_I2CM_SMC_EXT_ODR_EN);
+
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_DMP_EXT_SEN_ODR_CFG, EXT_SENSOR_EN | (ext_odr[sel_odr] << EXT_ODR_OFFSET));
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_INT1_CONFIG1, INT1_STATUS_I2CM_DONE);
+
+			break;
+	}
+
+	if (err) {
+		LOG_ERR("Communication error: %d", err);
+	}
+	else {
+		ext_mode = mode;
+	}
+
+	return err;
+}
+
+uint16_t icm45_data_read(uint8_t *data, uint16_t len)
+{
+	int err = 0;
+	uint16_t total = 0;
+	uint16_t packets = UINT16_MAX;
+
+	if (ext_mag)
+	{
+		// we have aux mag working in autonomous mode
+		uint8_t interrupts;
+		err = ssi_reg_read_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_INT1_STATUS1, &interrupts);
+
+		if (interrupts & INT1_STATUS_I2CM_DONE)
+		{
+			// i2c master finished transfer, that means we have data for mag
+			if (len >= PACKET_SIZE) {
+				data[0] = 0x70; // magic tag for mag entry
+				// put data as fifo entry
+				err |= icm45_bank_read(ICM45686_IPREG_TOP1, ICM45686_I2CM_RD_DATA_0 + ext_mag->ext_dummy_bytes, &data[1], ext_mag->ext_burst);
+
+				data += PACKET_SIZE;
+				len -= PACKET_SIZE; 
+				total++;
+			}
+			else {
+				LOG_WRN("Cannot read mag data, as buffer is too small: %d bytes", len);
+			}
+		}
+	}
+
+	while (packets > 0 && len >= PACKET_SIZE)
+	{
+		uint8_t rawCount[2];
+		err |= ssi_burst_read(SENSOR_INTERFACE_DEV_IMU, ICM45686_FIFO_COUNT_0, &rawCount[0], 2);
+		packets = (uint16_t)(rawCount[0] << 8 | rawCount[1]); // Turn the 16 bits into a unsigned 16-bit value
+		if (!packets) // nothing to do
+			break;
+		float extra_read_packets = packets * fifo_multiplier;
+		packets += extra_read_packets;
+		uint16_t count = packets * PACKET_SIZE;
+		uint16_t limit = len / PACKET_SIZE;
+		if (packets > limit)
+		{
+			LOG_WRN("FIFO read buffer limit reached, %d packets dropped", packets - limit);
+			packets = limit;
+			count = packets * PACKET_SIZE;
+		}
+		err |= ssi_burst_read_interval(SENSOR_INTERFACE_DEV_IMU, ICM45686_FIFO_DATA, data, count, PACKET_SIZE);
+		if (err)
+			LOG_ERR("Communication error");
+		data += packets * PACKET_SIZE;
+		len -= packets * PACKET_SIZE;
+		total += packets;
+	}
+	return total;
+}
+
+static const uint8_t invalid[6] = {0x80, 0x00, 0x80, 0x00, 0x80, 0x00};
+
+int icm45_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
+{
+	index *= PACKET_SIZE;
+
+	if (data[index] == 0x70)
+	{
+		// our artifical mag entry we read earlier
+		if (ext_mag)
+		{
+			ext_mag->mag_process(&data[index+1], m);
+		}
+		return 0;
+	}
+
+	if (data[index] != 0x78) // ACCEL_EN, GYRO_EN, HIRES_EN, TMST_FIELD_EN
+		return 1; // Skip invalid header
+	// Empty packet is 7F filled
+	// combine into 20 bit values in 32 bit int
+	float a_raw[3] = {0};
+	float g_raw[3] = {0};
+	if (memcmp(&data[index + 1], invalid, sizeof(invalid))) // valid accel data
+	{
+		for (int i = 0; i < 3; i++) // accel x, y, z
+			a_raw[i] = (int32_t)((((uint32_t)data[index + 1 + (i * 2)]) << 24) | (((uint32_t)data[index + 2 + (i * 2)]) << 16) | (((uint32_t)data[index + 17 + i] & 0xF0) << 8));
+	}
+	if (memcmp(&data[index + 7], invalid, sizeof(invalid))) // valid gyro data
+	{
+		for (int i = 0; i < 3; i++) // gyro x, y, z
+			g_raw[i] = (int32_t)((((uint32_t)data[index + 7 + (i * 2)]) << 24) | (((uint32_t)data[index + 8 + (i * 2)]) << 16) | (((uint32_t)data[index + 17 + i] & 0x0F) << 12));
+	}
+	else if (!memcmp(&data[index + 1], invalid, sizeof(invalid))) // Skip invalid data
+	{
+		return 1;
+	}
+	for (int i = 0; i < 3; i++) // x, y, z
+	{
+		a_raw[i] *= accel_sensitivity_32;
+		g_raw[i] *= gyro_sensitivity_32;
+	}
+	memcpy(a, a_raw, sizeof(a_raw));
+	memcpy(g, g_raw, sizeof(g_raw));
+	return 0;
+}
+
 const sensor_imu_t sensor_imu_icm45686 = {
 	*icm45_init,
 	*icm45_shutdown,
@@ -543,8 +635,8 @@ const sensor_imu_t sensor_imu_icm45686 = {
 	*icm45_update_fs,
 	*icm45_update_odr,
 
-	*icm45_fifo_read,
-	*icm45_fifo_process,
+	*icm45_data_read,
+	*icm45_data_process,
 	*icm45_accel_read,
 	*icm45_gyro_read,
 	*icm45_temp_read,

--- a/src/sensor/imu/ICM45686.c
+++ b/src/sensor/imu/ICM45686.c
@@ -70,6 +70,9 @@ int icm45_init(float clock_rate, float accel_time, float gyro_time, float *accel
 	err |= icm45_update_odr(accel_time, gyro_time, accel_actual_time, gyro_actual_time);
 	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_FIFO_CONFIG0, 0x80 | 0b000111); // set FIFO stop-on-full mode, set FIFO depth to 2K bytes (see AN-000364)
 	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_FIFO_CONFIG3, 0x0F); // begin FIFO stream, hires, a+g
+
+	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_INT1_CONFIG2, INT1_MODE); // latch mode, push pull
+
 	if (err)
 		LOG_ERR("Communication error");
 	return (err < 0 ? err : 0);
@@ -454,7 +457,7 @@ int icm45_ext_write_read(const uint8_t addr, const uint8_t *write_buf, size_t nu
 	return err;
 }
 
-int icm45_ext_setup(enum sensor_ext_mode mode, const sensor_mag_t *mag, uint8_t mag_addr) {
+int icm45_ext_setup(sensor_ext_mode_t mode, const sensor_mag_t *mag, uint8_t mag_addr) {
 	int err = 0;
 	ext_mag = NULL; // only autonomous mode will set this 
 
@@ -531,13 +534,13 @@ uint16_t icm45_data_read(uint8_t *data, uint16_t len)
 	uint16_t total = 0;
 	uint16_t packets = UINT16_MAX;
 
+	uint8_t int1_status[2] = {0};
+	err = ssi_burst_read(SENSOR_INTERFACE_DEV_IMU, ICM45686_INT1_STATUS0, int1_status, 2);
+
 	if (ext_mag)
 	{
 		// we have aux mag working in autonomous mode
-		uint8_t interrupts;
-		err = ssi_reg_read_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_INT1_STATUS1, &interrupts);
-
-		if (interrupts & INT1_STATUS_I2CM_DONE)
+		if (int1_status[1] & INT1_STATUS_I2CM_DONE)
 		{
 			// i2c master finished transfer, that means we have data for mag
 			if (len >= PACKET_SIZE) {
@@ -553,38 +556,60 @@ uint16_t icm45_data_read(uint8_t *data, uint16_t len)
 				LOG_WRN("Cannot read mag data, as buffer is too small: %d bytes", len);
 			}
 		}
+
+		// // set if we should maybe also read fifo
+		// err = ssi_reg_read_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_INT1_STATUS0, &int1_status);
+		// int1 = int1_status;
+
+		// if (!(int1_status & INT1_STATUS_FIFO_THS))
+		// {
+		// 	// fifo threshold not exceeded, skip reading it for now
+		// 	if (total == 0) {
+		// 		LOG_WRN("No data to read int flags 0x%x 0x%x", int0, int1);
+		// 	}
+		// 	return total;
+		// }
 	}
 
-	while (packets > 0 && len >= PACKET_SIZE)
-	{
-		uint8_t rawCount[2];
-		err |= ssi_burst_read(SENSOR_INTERFACE_DEV_IMU, ICM45686_FIFO_COUNT_0, &rawCount[0], 2);
-		packets = (uint16_t)(rawCount[0] << 8 | rawCount[1]); // Turn the 16 bits into a unsigned 16-bit value
-		if (!packets) // nothing to do
-			break;
-		float extra_read_packets = packets * fifo_multiplier;
-		packets += extra_read_packets;
-		uint16_t count = packets * PACKET_SIZE;
-		uint16_t limit = len / PACKET_SIZE;
-		if (packets > limit)
+	if (int1_status[0] & INT1_STATUS_FIFO_THS) {
+
+		while (packets > 0 && len >= PACKET_SIZE)
 		{
-			LOG_WRN("FIFO read buffer limit reached, %d packets dropped", packets - limit);
-			packets = limit;
-			count = packets * PACKET_SIZE;
+			uint8_t rawCount[2];
+			err |= ssi_burst_read(SENSOR_INTERFACE_DEV_IMU, ICM45686_FIFO_COUNT_0, &rawCount[0], 2);
+			packets = (uint16_t)(rawCount[0] << 8 | rawCount[1]); // Turn the 16 bits into a unsigned 16-bit value
+			if (!packets) // nothing to do
+				break;
+			float extra_read_packets = packets * fifo_multiplier;
+			packets += extra_read_packets;
+			uint16_t count = packets * PACKET_SIZE;
+			uint16_t limit = len / PACKET_SIZE;
+			if (packets > limit)
+			{
+				LOG_WRN("FIFO read buffer limit reached, %d packets dropped", packets - limit);
+				packets = limit;
+				count = packets * PACKET_SIZE;
+			}
+			err |= ssi_burst_read_interval(SENSOR_INTERFACE_DEV_IMU, ICM45686_FIFO_DATA, data, count, PACKET_SIZE);
+			if (err)
+				LOG_ERR("Communication error");
+			data += packets * PACKET_SIZE;
+			len -= packets * PACKET_SIZE;
+			total += packets;
 		}
-		err |= ssi_burst_read_interval(SENSOR_INTERFACE_DEV_IMU, ICM45686_FIFO_DATA, data, count, PACKET_SIZE);
-		if (err)
-			LOG_ERR("Communication error");
-		data += packets * PACKET_SIZE;
-		len -= packets * PACKET_SIZE;
-		total += packets;
 	}
+
+	if (total == 0) {
+		LOG_WRN("no data");
+		LOG_WRN("flags 0x%x 0x%x", int1_status[0], int1_status[1]);
+	}
+
 	return total;
 }
 
 static const uint8_t invalid[6] = {0x80, 0x00, 0x80, 0x00, 0x80, 0x00};
 
-int icm45_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
+sensor_data_attrs_t icm45_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
 {
 	index *= PACKET_SIZE;
 
@@ -594,38 +619,46 @@ int icm45_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], fl
 		if (ext_mag)
 		{
 			ext_mag->mag_process(&data[index+1], m);
+			return DATA_VALID_MAG | DATA_OUTSIDE_FIFO;
+
 		}
-		return 0;
+		else {
+			return DATA_OUTSIDE_FIFO;
+		}
 	}
 
 	if (data[index] != 0x78) // ACCEL_EN, GYRO_EN, HIRES_EN, TMST_FIELD_EN
-		return 1; // Skip invalid header
+		return DATA_INVALID; // Skip invalid header
+
+	sensor_data_attrs_t result = 0;
+
 	// Empty packet is 7F filled
 	// combine into 20 bit values in 32 bit int
-	float a_raw[3] = {0};
-	float g_raw[3] = {0};
 	if (memcmp(&data[index + 1], invalid, sizeof(invalid))) // valid accel data
 	{
 		for (int i = 0; i < 3; i++) // accel x, y, z
-			a_raw[i] = (int32_t)((((uint32_t)data[index + 1 + (i * 2)]) << 24) | (((uint32_t)data[index + 2 + (i * 2)]) << 16) | (((uint32_t)data[index + 17 + i] & 0xF0) << 8));
+			a[i] = (int32_t)((((uint32_t)data[index + 1 + (i * 2)]) << 24) | (((uint32_t)data[index + 2 + (i * 2)]) << 16) | (((uint32_t)data[index + 17 + i] & 0xF0) << 8));
+
+		result |= DATA_VALID_ACCEL;
 	}
 	if (memcmp(&data[index + 7], invalid, sizeof(invalid))) // valid gyro data
 	{
 		for (int i = 0; i < 3; i++) // gyro x, y, z
-			g_raw[i] = (int32_t)((((uint32_t)data[index + 7 + (i * 2)]) << 24) | (((uint32_t)data[index + 8 + (i * 2)]) << 16) | (((uint32_t)data[index + 17 + i] & 0x0F) << 12));
+			g[i] = (int32_t)((((uint32_t)data[index + 7 + (i * 2)]) << 24) | (((uint32_t)data[index + 8 + (i * 2)]) << 16) | (((uint32_t)data[index + 17 + i] & 0x0F) << 12));
+
+		result |= DATA_VALID_GYRO;
 	}
 	else if (!memcmp(&data[index + 1], invalid, sizeof(invalid))) // Skip invalid data
 	{
-		return 1;
+		return DATA_INVALID;
 	}
 	for (int i = 0; i < 3; i++) // x, y, z
 	{
-		a_raw[i] *= accel_sensitivity_32;
-		g_raw[i] *= gyro_sensitivity_32;
+		a[i] *= accel_sensitivity_32;
+		g[i] *= gyro_sensitivity_32;
 	}
-	memcpy(a, a_raw, sizeof(a_raw));
-	memcpy(g, g_raw, sizeof(g_raw));
-	return 0;
+
+	return result;
 }
 
 const sensor_imu_t sensor_imu_icm45686 = {

--- a/src/sensor/imu/ICM45686.c
+++ b/src/sensor/imu/ICM45686.c
@@ -556,19 +556,6 @@ uint16_t icm45_data_read(uint8_t *data, uint16_t len)
 				LOG_WRN("Cannot read mag data, as buffer is too small: %d bytes", len);
 			}
 		}
-
-		// // set if we should maybe also read fifo
-		// err = ssi_reg_read_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_INT1_STATUS0, &int1_status);
-		// int1 = int1_status;
-
-		// if (!(int1_status & INT1_STATUS_FIFO_THS))
-		// {
-		// 	// fifo threshold not exceeded, skip reading it for now
-		// 	if (total == 0) {
-		// 		LOG_WRN("No data to read int flags 0x%x 0x%x", int0, int1);
-		// 	}
-		// 	return total;
-		// }
 	}
 
 	if (int1_status[0] & INT1_STATUS_FIFO_THS) {
@@ -600,8 +587,7 @@ uint16_t icm45_data_read(uint8_t *data, uint16_t len)
 	}
 
 	if (total == 0) {
-		LOG_WRN("no data");
-		LOG_WRN("flags 0x%x 0x%x", int1_status[0], int1_status[1]);
+		LOG_WRN("No data, interrupts 0x%x 0x%x", int1_status[0], int1_status[1]);
 	}
 
 	return total;

--- a/src/sensor/imu/ICM45686.c
+++ b/src/sensor/imu/ICM45686.c
@@ -356,22 +356,30 @@ uint8_t icm45_setup_WOM(void) // TODO: check if working
 	return NRF_GPIO_PIN_PULLUP << 4 | NRF_GPIO_PIN_SENSE_LOW; // active low
 }
 
-int icm45_ext_passthrough(bool passthrough)
-{
+int icm45_ext_setup(enum sensor_ext_mode mode) {
 	int err = 0;
-	if (passthrough)
-		err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IOC_PAD_SCENARIO_AUX_OVRD, 0x18); // AUX1_MODE_OVRD, AUX1 in I2CM Bypass
-	else
-		err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IOC_PAD_SCENARIO_AUX_OVRD, 0x00); // disable overrides
-	if (err)
-		LOG_ERR("Communication error");
-	return 0;
-}
+	switch (mode) {
+		case SENSOR_EXT_MODE_OFF:
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IOC_PAD_SCENARIO_AUX_OVRD, 0x00); // disable overrides
+			break;
 
-int icm45_ext_setup() {
-	int err = 0;
-	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IOC_PAD_SCENARIO_AUX_OVRD, 0x17); // AUX1_MODE_OVRD, AUX1 in I2CM Master, AUX1_ENABLE_OVRD, AUX1 enabled
-	sensor_interface_ext_configure(&sensor_ext_icm45686);
+		case SENSOR_EXT_MODE_I2C_PASSTHROUGH:
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IOC_PAD_SCENARIO_AUX_OVRD, 0x18); // AUX1_MODE_OVRD, AUX1 in I2CM Bypass
+			break;
+			
+		case SENSOR_EXT_MODE_I2CM_PROXY:
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_IOC_PAD_SCENARIO_AUX_OVRD, 0x17); // AUX1_MODE_OVRD, AUX1 in I2CM Master, AUX1_ENABLE_OVRD, AUX1 enabled
+			sensor_interface_ext_configure(&sensor_ext_icm45686);
+			break;
+		
+		case SENSOR_EXT_MODE_I2CM_AUTONOMOUS:
+			return -1;
+	}
+
+	if (err) {
+		LOG_ERR("Communication error: %d", err);
+	}
+
 	return err;
 }
 
@@ -544,8 +552,7 @@ const sensor_imu_t sensor_imu_icm45686 = {
 	*icm45_setup_DRDY,
 	*icm45_setup_WOM,
 
-	*icm45_ext_setup,
-	*icm45_ext_passthrough
+	*icm45_ext_setup
 };
 
 const sensor_ext_ssi_t sensor_ext_icm45686 = {

--- a/src/sensor/imu/ICM45686.c
+++ b/src/sensor/imu/ICM45686.c
@@ -40,6 +40,7 @@ int icm45_init(float clock_rate, float accel_time, float gyro_time, float *accel
 	else
 		fifo_multiplier_factor = FIFO_MULT; // I2C mode
 	int err = 0;
+
 	if (clock_rate > 0)
 	{
 		clock_scale = clock_rate / clock_reference;
@@ -52,18 +53,19 @@ int icm45_init(float clock_rate, float accel_time, float gyro_time, float *accel
 	ireg_buf[1] = ICM45686_IPREG_BAR_REG_58;
 	ireg_buf[2] = 0xD9 & ~0x48; // disable internal pull resistors for AP pins (pin 13, 12)
 	err |= ssi_burst_write(SENSOR_INTERFACE_DEV_IMU, ICM45686_IREG_ADDR_15_8, ireg_buf, 3); // write buffer
+	k_usleep(4); // Wait 4uS after writing IREG, as per datasheet
 	ireg_buf[1] = ICM45686_IPREG_BAR_REG_59;
 	ireg_buf[2] = 0xB6 & ~0x92; // disable internal pull resistors for AP pins (pin 7, 1, 14)
 	err |= ssi_burst_write(SENSOR_INTERFACE_DEV_IMU, ICM45686_IREG_ADDR_15_8, ireg_buf, 3); // write buffer
+	k_usleep(4); // Wait 4uS after writing IREG, as per datasheet
 	ireg_buf[0] = ICM45686_IPREG_TOP1; // address is a word, icm is big endian
 	ireg_buf[1] = ICM45686_SREG_CTRL;
 	ireg_buf[2] = 0x02; // set big endian
 	err |= ssi_burst_write(SENSOR_INTERFACE_DEV_IMU, ICM45686_IREG_ADDR_15_8, ireg_buf, 3); // write buffer
+	k_usleep(4); // Wait 4uS after writing IREG, as per datasheet
 	last_accel_odr = 0xff; // reset last odr
 	last_gyro_odr = 0xff; // reset last odr
 	err |= icm45_update_odr(accel_time, gyro_time, accel_actual_time, gyro_actual_time);
-//	k_msleep(50); // 10ms Accel, 30ms Gyro startup
-	k_msleep(1); // fuck i dont wanna wait that long
 	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_FIFO_CONFIG0, 0x80 | 0b000111); // set FIFO stop-on-full mode, set FIFO depth to 2K bytes (see AN-000364)
 	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_FIFO_CONFIG3, 0x0F); // begin FIFO stream, hires, a+g
 	if (err)
@@ -75,11 +77,9 @@ void icm45_shutdown(void)
 {
 	last_accel_odr = 0xff; // reset last odr
 	last_gyro_odr = 0xff; // reset last odr
-	int err = ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_REG_MISC2, 0x02); // Don't need to wait for ICM to finish reset
+	int err = ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_REG_MISC2, 0x02);
 	aux_addr = 0;
 	aux_reg = 0;
-//	k_msleep(1);
-	// TODO: not working
 //	uint8_t ireg_buf[3];
 //	ireg_buf[1] = ICM45686_IPREG_BAR_REG_60;
 //	ireg_buf[2] = 0x6D & ~0x05; // set internal pull down resistors for AP pins (pin 10, 7)
@@ -87,6 +87,21 @@ void icm45_shutdown(void)
 //	ireg_buf[1] = ICM45686_IPREG_BAR_REG_61;
 //	ireg_buf[2] = 0xBB & ~0x10; // set internal pull down resistors for AP pins (pin 11)
 //	err |= ssi_burst_write(SENSOR_INTERFACE_DEV_IMU, ICM45686_IREG_ADDR_15_8, ireg_buf, 3); // write buffer
+	// Wait to finish reset
+	uint8_t rst_state;
+	while(true) {
+		err |= ssi_reg_read_byte(SENSOR_INTERFACE_DEV_IMU, ICM45686_INT1_STATUS0, &rst_state);
+		if (err) {
+			LOG_ERR("Communication error when reading reset state");
+			break;
+		}
+		if((rst_state & 0x80) != 0x80) {
+			k_usleep(10);
+			LOG_DBG("IMU reset is pending (0x%02x), waiting...", rst_state);
+		} else {
+			break;
+		}
+	}
 	if (err)
 		LOG_ERR("Communication error");
 }

--- a/src/sensor/imu/ICM45686.h
+++ b/src/sensor/imu/ICM45686.h
@@ -53,6 +53,15 @@
 // User Bank IPREG_TOP1
 #define ICM45686_IPREG_TOP1                0xA2 // MSB
 
+#define ICM45686_I2CM_COMMAND_0            0x06
+#define ICM45686_DEV_PROFILE_0             0x0e
+#define ICM45686_DEV_PROFILE_1             0x0f
+#define ICM45686_I2CM_CONTROL              0x16
+#define ICM45686_I2CM_STATUS               0x18
+#define ICM45686_I2CM_EXT_DEV_STATUS       0x1a
+#define ICM45686_I2CM_RD_DATA_0            0x1b
+#define ICM45686_I2CM_WR_DATA_0            0x33
+
 #define ICM45686_SMC_CONTROL_0             0x58
 
 #define ICM45686_SREG_CTRL                 0x67

--- a/src/sensor/imu/ICM45686.h
+++ b/src/sensor/imu/ICM45686.h
@@ -19,6 +19,7 @@
 
 #define ICM45686_INT1_CONFIG0              0x16
 #define ICM45686_INT1_CONFIG1              0x17
+#define ICM45686_INT1_CONFIG2              0x18
 
 #define ICM45686_INT1_STATUS0              0x19
 #define ICM45686_INT1_STATUS1              0x1A
@@ -188,10 +189,16 @@ writing to the register pointed by the post-auto-incremented address.
 
 #define INT_STATUS_I2CM_SMC_EXT_ODR_EN (1 << 1) // trigger eDMP operation on target ODR (without that i2cm don't start automatically) 
 
+#define INT1_STATUS_FIFO_THS (1 << 1)
 #define INT1_STATUS_I2CM_DONE (1 << 5) // bit set to 1 in int1_status register when i2cm finished operation
 #define INT1_STATUS_WOM_X  (1 << 1)
 #define INT1_STATUS_WOM_Y  (1 << 2)
 #define INT1_STATUS_WOM_Z  (1 << 3)
+
+#define INT1_POLARITY (1 << 0)
+#define INT1_MODE     (1 << 1)
+#define INT1_DRIVE    (1 << 2)
+
 
 
 int icm45_init(float clock_rate, float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time);
@@ -201,7 +208,7 @@ void icm45_update_fs(float accel_range, float gyro_range, float *accel_actual_ra
 int icm45_update_odr(float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time);
 
 uint16_t icm45_data_read(uint8_t *data, uint16_t len);
-int icm45_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3]);
+sensor_data_attrs_t icm45_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3]);
 void icm45_accel_read(float a[3]);
 void icm45_gyro_read(float g[3]);
 int icm45_temp_read(float *data);
@@ -209,7 +216,7 @@ int icm45_temp_read(float *data);
 uint8_t icm45_setup_DRDY(uint16_t threshold);
 uint8_t icm45_setup_WOM(void);
 
-int icm45_ext_setup(enum sensor_ext_mode mode, const sensor_mag_t *, uint8_t mag_addr);
+int icm45_ext_setup(sensor_ext_mode_t mode, const sensor_mag_t *, uint8_t mag_addr);
 
 int icm45_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes);
 int icm45_ext_write_read(const uint8_t addr, const uint8_t *write_buf, size_t num_write, uint8_t *read_buf, size_t num_read);

--- a/src/sensor/imu/ICM45686.h
+++ b/src/sensor/imu/ICM45686.h
@@ -21,6 +21,7 @@
 #define ICM45686_INT1_CONFIG1              0x17
 
 #define ICM45686_INT1_STATUS0              0x19
+#define ICM45686_INT1_STATUS1              0x1A
 
 #define ICM45686_ACCEL_CONFIG0             0x1B
 #define ICM45686_GYRO_CONFIG0              0x1C
@@ -28,10 +29,16 @@
 #define ICM45686_FIFO_CONFIG0              0x1D
 #define ICM45686_FIFO_CONFIG1_0            0x1E
 #define ICM45686_FIFO_CONFIG3              0x21
+#define ICM45686_FIFO_CONFIG4              0x22
+
 
 #define ICM45686_TMST_WOM_CONFIG           0x23
 
 #define ICM45686_RTC_CONFIG                0x26
+
+#define ICM45686_DMP_EXT_SEN_ODR_CFG       0x27
+
+
 #define ICM45686_IOC_PAD_SCENARIO_AUX_OVRD 0x30
 #define ICM45686_IOC_PAD_SCENARIO_OVRD     0x31 // see application note
 
@@ -65,6 +72,8 @@
 #define ICM45686_SMC_CONTROL_0             0x58
 
 #define ICM45686_SREG_CTRL                 0x67
+
+#define ICM45686_INT_I2CM_SOURCE           0x74
 
 #define ICM45686_ACCEL_WOM_X_THR           0x7E
 #define ICM45686_ACCEL_WOM_Y_THR           0x7F
@@ -127,6 +136,19 @@ writing to the register pointed by the post-auto-incremented address.
 #define ACCEL_ODR_3_125Hz  0x0E
 #define ACCEL_ODR_1_5625Hz 0x0F
 
+#define EXT_SENSOR_EN    0x40
+#define EXT_ODR_OFFSET   0x03
+
+#define EXT_ODR_400Hz    0x07
+#define EXT_ODR_200Hz    0x06
+#define EXT_ODR_100Hz    0x05
+#define EXT_ODR_50Hz     0x04
+#define EXT_ODR_25Hz     0x03
+#define EXT_ODR_12_5Hz   0x02
+#define EXT_ODR_6_25Hz   0x01
+#define EXT_ODR_3_125Hz  0x00
+
+
 #define GYRO_UI_FS_SEL_4000DPS   0x00
 #define GYRO_UI_FS_SEL_2000DPS   0x01
 #define GYRO_UI_FS_SEL_1000DPS   0x02
@@ -154,14 +176,32 @@ writing to the register pointed by the post-auto-incremented address.
 #define GYRO_ODR_3_125Hz  0x0E
 #define GYRO_ODR_1_5625Hz 0x0F
 
+// Fifo header fields - telling what is included in fifo packets
+#define FIFO_EXT_HEADER    (1 << 7)
+#define FIFO_ACCEL_EN      (1 << 6)
+#define FIFO_GYRO_EN       (1 << 5)
+#define FIFO_HIRES_EN      (1 << 4)
+#define FIFO_TMST_FIELD_EN (1 << 3)
+#define FIFO_FSYNC_TAG_EN  (1 << 2)
+#define FIFO_ACCEL_ODR     (1 << 1)
+#define FIFO_GYRO_ODR      (1 << 0)
+
+#define INT_STATUS_I2CM_SMC_EXT_ODR_EN (1 << 1) // trigger eDMP operation on target ODR (without that i2cm don't start automatically) 
+
+#define INT1_STATUS_I2CM_DONE (1 << 5) // bit set to 1 in int1_status register when i2cm finished operation
+#define INT1_STATUS_WOM_X  (1 << 1)
+#define INT1_STATUS_WOM_Y  (1 << 2)
+#define INT1_STATUS_WOM_Z  (1 << 3)
+
+
 int icm45_init(float clock_rate, float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time);
 void icm45_shutdown(void);
 
 void icm45_update_fs(float accel_range, float gyro_range, float *accel_actual_range, float *gyro_actual_range);
 int icm45_update_odr(float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time);
 
-uint16_t icm45_fifo_read(uint8_t *data, uint16_t len);
-int icm45_fifo_process(uint16_t index, uint8_t *data, float a[3], float g[3]);
+uint16_t icm45_data_read(uint8_t *data, uint16_t len);
+int icm45_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3]);
 void icm45_accel_read(float a[3]);
 void icm45_gyro_read(float g[3]);
 int icm45_temp_read(float *data);
@@ -169,7 +209,7 @@ int icm45_temp_read(float *data);
 uint8_t icm45_setup_DRDY(uint16_t threshold);
 uint8_t icm45_setup_WOM(void);
 
-int icm45_ext_setup(enum sensor_ext_mode mode);
+int icm45_ext_setup(enum sensor_ext_mode mode, const sensor_mag_t *, uint8_t mag_addr);
 
 int icm45_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes);
 int icm45_ext_write_read(const uint8_t addr, const uint8_t *write_buf, size_t num_write, uint8_t *read_buf, size_t num_read);

--- a/src/sensor/imu/ICM45686.h
+++ b/src/sensor/imu/ICM45686.h
@@ -173,7 +173,7 @@ int icm45_ext_setup(void);
 int icm45_ext_passthrough(bool passthrough);
 
 int icm45_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes);
-int icm45_ext_write_read(const uint8_t addr, const void *write_buf, size_t num_write, void *read_buf, size_t num_read);
+int icm45_ext_write_read(const uint8_t addr, const uint8_t *write_buf, size_t num_write, uint8_t *read_buf, size_t num_read);
 
 extern const sensor_imu_t sensor_imu_icm45686;
 extern const sensor_ext_ssi_t sensor_ext_icm45686;

--- a/src/sensor/imu/ICM45686.h
+++ b/src/sensor/imu/ICM45686.h
@@ -169,8 +169,7 @@ int icm45_temp_read(float *data);
 uint8_t icm45_setup_DRDY(uint16_t threshold);
 uint8_t icm45_setup_WOM(void);
 
-int icm45_ext_setup(void);
-int icm45_ext_passthrough(bool passthrough);
+int icm45_ext_setup(enum sensor_ext_mode mode);
 
 int icm45_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes);
 int icm45_ext_write_read(const uint8_t addr, const uint8_t *write_buf, size_t num_write, uint8_t *read_buf, size_t num_read);

--- a/src/sensor/imu/ISM330BX.c
+++ b/src/sensor/imu/ISM330BX.c
@@ -8,7 +8,7 @@
 
 LOG_MODULE_REGISTER(ISM330BX, LOG_LEVEL_DBG);
 
-int ism_fifo_process(uint16_t index, uint8_t *data, float a[3], float g[3])
+int ism_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
 {
 	index *= PACKET_SIZE;
 	switch (data[index] >> 3)
@@ -53,8 +53,8 @@ const sensor_imu_t sensor_imu_ism330bx = {
 	*lsm_update_fs,
 	*lsm_update_odr,
 
-	*lsm_fifo_read,
-	*ism_fifo_process,
+	*lsm_data_read,
+	*ism_data_process,
 	*ism_accel_read,
 	*lsm_gyro_read,
 	*lsm_temp_read,

--- a/src/sensor/imu/ISM330BX.c
+++ b/src/sensor/imu/ISM330BX.c
@@ -62,6 +62,5 @@ const sensor_imu_t sensor_imu_ism330bx = {
 	*lsm_setup_DRDY,
 	*lsm_setup_WOM,
 
-	*lsm_ext_setup,
-	*lsm_ext_passthrough
+	*lsm_ext_setup
 };

--- a/src/sensor/imu/ISM330BX.c
+++ b/src/sensor/imu/ISM330BX.c
@@ -8,7 +8,7 @@
 
 LOG_MODULE_REGISTER(ISM330BX, LOG_LEVEL_DBG);
 
-int ism_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
+sensor_data_attrs_t ism_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
 {
 	index *= PACKET_SIZE;
 	switch (data[index] >> 3)
@@ -19,18 +19,18 @@ int ism_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], floa
 			a[2 - i] = (int16_t)((((uint16_t)data[index + 2 + (i * 2)]) << 8) | data[index + 1 + (i * 2)]);
 			a[2 - i] *= accel_sensitivity;
 		}
-		return 0;
+		return DATA_VALID_ACCEL;
 	case 0x01: // Gyroscope NC (Gyroscope uncompressed data)
 		for (int i = 0; i < 3; i++) // x, y, z
 		{
 			g[i] = (int16_t)((((uint16_t)data[index + 2 + (i * 2)]) << 8) | data[index + 1 + (i * 2)]);
 			g[i] *= gyro_sensitivity;
 		}
-		return 0;
+		return DATA_VALID_GYRO;
 	default:
 	}
 	// TODO: need to skip invalid data
-	return 1;
+	return DATA_INVALID;
 }
 
 void ism_accel_read(float a[3])

--- a/src/sensor/imu/LSM6DSM.c
+++ b/src/sensor/imu/LSM6DSM.c
@@ -304,6 +304,5 @@ const sensor_imu_t sensor_imu_lsm6dsm = {
 	*lsm6dsm_setup_DRDY,
 	*lsm6dsm_setup_WOM,
 
-	*imu_none_ext_setup,
-	*lsm_ext_passthrough
+	*lsm_ext_setup
 };

--- a/src/sensor/imu/LSM6DSM.c
+++ b/src/sensor/imu/LSM6DSM.c
@@ -223,7 +223,7 @@ uint16_t lsm6dsm_data_read(uint8_t *data, uint16_t len)
 	return total;
 }
 
-int lsm6dsm_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
+sensor_data_attrs_t lsm6dsm_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
 {
 	index *= PACKET_SIZE;
 	uint8_t pattern = data[index];
@@ -234,7 +234,7 @@ int lsm6dsm_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], 
 			g[i] = (int16_t)((((uint16_t)data[index + 2 + (i * 2)]) << 8) | data[index + 1 + (i * 2)]);
 			g[i] *= gyro_sensitivity;
 		}
-		return 0;
+		return DATA_VALID_GYRO;
 	}
 	else
 	{
@@ -243,9 +243,9 @@ int lsm6dsm_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], 
 			a[i] = (int16_t)((((uint16_t)data[index + 2 + (i * 2)]) << 8) | data[index + 1 + (i * 2)]);
 			a[i] *= accel_sensitivity;
 		}
-		return 0;
+		return DATA_VALID_ACCEL;
 	}
-	return 1;
+	return DATA_INVALID;
 }
 
 /* LSM6DSM does not have COUNTER_BDR, FIFO threshold uses word count, or 3 words per sensor sample

--- a/src/sensor/imu/LSM6DSM.c
+++ b/src/sensor/imu/LSM6DSM.c
@@ -180,7 +180,7 @@ int lsm6dsm_update_odr(float accel_time, float gyro_time, float *accel_actual_ti
 	return 0;
 }
 
-uint16_t lsm6dsm_fifo_read(uint8_t *data, uint16_t len)
+uint16_t lsm6dsm_data_read(uint8_t *data, uint16_t len)
 {
 	int err = 0;
 	uint16_t total = 0;
@@ -223,7 +223,7 @@ uint16_t lsm6dsm_fifo_read(uint8_t *data, uint16_t len)
 	return total;
 }
 
-int lsm6dsm_fifo_process(uint16_t index, uint8_t *data, float a[3], float g[3])
+int lsm6dsm_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
 {
 	index *= PACKET_SIZE;
 	uint8_t pattern = data[index];
@@ -295,8 +295,8 @@ const sensor_imu_t sensor_imu_lsm6dsm = {
 	*lsm6dsm_update_fs,
 	*lsm6dsm_update_odr,
 
-	*lsm6dsm_fifo_read,
-	*lsm6dsm_fifo_process,
+	*lsm6dsm_data_read,
+	*lsm6dsm_data_process,
 	*lsm_accel_read,
 	*lsm_gyro_read,
 	*lsm_temp_read,

--- a/src/sensor/imu/LSM6DSM.h
+++ b/src/sensor/imu/LSM6DSM.h
@@ -64,8 +64,8 @@ int lsm6dsm_init(float clock_rate, float accel_time, float gyro_time, float *acc
 void lsm6dsm_update_fs(float accel_range, float gyro_range, float *accel_actual_range, float *gyro_actual_range);
 int lsm6dsm_update_odr(float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time);
 
-uint16_t lsm6dsm_fifo_read(uint8_t *data, uint16_t len);
-uint16_t lsm6dsm_fifo_read(uint8_t *data, uint16_t len);
+uint16_t lsm6dsm_data_read(uint8_t *data, uint16_t len);
+uint16_t lsm6dsm_data_read(uint8_t *data, uint16_t len);
 
 uint8_t lsm6dsm_setup_DRDY(uint16_t threshold);
 uint8_t lsm6dsm_setup_WOM(void);

--- a/src/sensor/imu/LSM6DSO.c
+++ b/src/sensor/imu/LSM6DSO.c
@@ -164,7 +164,7 @@ int lsm6dso_update_odr(float accel_time, float gyro_time, float *accel_actual_ti
 	return 0;
 }
 
-uint16_t lsm6dso_fifo_read(uint8_t *data, uint16_t len)
+uint16_t lsm6dso_data_read(uint8_t *data, uint16_t len)
 {
 	int err = 0;
 	uint16_t total = 0;
@@ -213,7 +213,7 @@ uint8_t lsm6dso_setup_WOM(void)
 	return NRF_GPIO_PIN_PULLUP << 4 | NRF_GPIO_PIN_SENSE_LOW; // active low
 }
 
-int lsm6dso_ext_setup(enum sensor_ext_mode mode) {
+int lsm6dso_ext_setup(enum sensor_ext_mode mode, const sensor_mag_t *mag, uint8_t mag_addr) {
 	int err = 0;
 	switch (mode) {
 		case SENSOR_EXT_MODE_OFF:
@@ -318,8 +318,8 @@ const sensor_imu_t sensor_imu_lsm6dso = {
 	*lsm6dso_update_fs,
 	*lsm6dso_update_odr,
 
-	*lsm6dso_fifo_read,
-	*lsm_fifo_process,
+	*lsm6dso_data_read,
+	*lsm_data_process,
 	*lsm_accel_read,
 	*lsm_gyro_read,
 	*lsm_temp_read,

--- a/src/sensor/imu/LSM6DSO.c
+++ b/src/sensor/imu/LSM6DSO.c
@@ -271,7 +271,7 @@ int lsm6dso_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes
 	return err;
 }
 
-int lsm6dso_ext_write_read(const uint8_t addr, const void *write_buf, size_t num_write, void *read_buf, size_t num_read)
+int lsm6dso_ext_write_read(const uint8_t addr, const uint8_t *write_buf, size_t num_write, uint8_t *read_buf, size_t num_read)
 {
 	if (num_write != 1 || num_read < 1 || num_read > 8)
 	{

--- a/src/sensor/imu/LSM6DSO.c
+++ b/src/sensor/imu/LSM6DSO.c
@@ -213,30 +213,34 @@ uint8_t lsm6dso_setup_WOM(void)
 	return NRF_GPIO_PIN_PULLUP << 4 | NRF_GPIO_PIN_SENSE_LOW; // active low
 }
 
-int lsm6dso_ext_setup(void)
-{
-	sensor_interface_ext_configure(&sensor_ext_lsm6dsv);
-	return 0;
-}
-
-int lsm6dso_ext_passthrough(bool passthrough)
-{
+int lsm6dso_ext_setup(enum sensor_ext_mode mode) {
 	int err = 0;
-	if (passthrough)
-	{
-		err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_FUNC_CFG_ACCESS, 0x40); // switch to sensor hub registers
-		err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_MASTER_CONFIG, 0x10); // passthrough on
-		err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_FUNC_CFG_ACCESS, 0x00); // switch to normal registers
+	switch (mode) {
+		case SENSOR_EXT_MODE_OFF:
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_FUNC_CFG_ACCESS, 0x40); // switch to sensor hub registers
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_MASTER_CONFIG, 0x08); // passthrough off
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_FUNC_CFG_ACCESS, 0x00); // switch to normal registers
+			break;
+
+		case SENSOR_EXT_MODE_I2C_PASSTHROUGH:
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_FUNC_CFG_ACCESS, 0x40); // switch to sensor hub registers
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_MASTER_CONFIG, 0x10); // passthrough on
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_FUNC_CFG_ACCESS, 0x00); // switch to normal registers
+			break;
+			
+		case SENSOR_EXT_MODE_I2CM_PROXY:
+			sensor_interface_ext_configure(&sensor_ext_lsm6dsv);
+			break;
+		
+		case SENSOR_EXT_MODE_I2CM_AUTONOMOUS:
+			return -1;
 	}
-	else
-	{
-		err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_FUNC_CFG_ACCESS, 0x40); // switch to sensor hub registers
-		err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_MASTER_CONFIG, 0x08); // passthrough off
-		err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_FUNC_CFG_ACCESS, 0x00); // switch to normal registers
+
+	if (err) {
+		LOG_ERR("Communication error: %d", err);
 	}
-	if (err)
-		LOG_ERR("Communication error");
-	return 0;
+
+	return err;
 }
 
 int lsm6dso_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes)
@@ -323,8 +327,7 @@ const sensor_imu_t sensor_imu_lsm6dso = {
 	*lsm_setup_DRDY,
 	*lsm6dso_setup_WOM,
 
-	*lsm6dso_ext_setup,
-	*lsm6dso_ext_passthrough
+	*lsm6dso_ext_setup
 };
 
 const sensor_ext_ssi_t sensor_ext_lsm6dso = {

--- a/src/sensor/imu/LSM6DSO.c
+++ b/src/sensor/imu/LSM6DSO.c
@@ -213,7 +213,7 @@ uint8_t lsm6dso_setup_WOM(void)
 	return NRF_GPIO_PIN_PULLUP << 4 | NRF_GPIO_PIN_SENSE_LOW; // active low
 }
 
-int lsm6dso_ext_setup(enum sensor_ext_mode mode, const sensor_mag_t *mag, uint8_t mag_addr) {
+int lsm6dso_ext_setup(sensor_ext_mode_t mode, const sensor_mag_t *mag, uint8_t mag_addr) {
 	int err = 0;
 	switch (mode) {
 		case SENSOR_EXT_MODE_OFF:

--- a/src/sensor/imu/LSM6DSO.h
+++ b/src/sensor/imu/LSM6DSO.h
@@ -72,7 +72,7 @@ uint16_t lsm6dso_data_read(uint8_t *data, uint16_t len);
 
 uint8_t lsm6dso_setup_WOM(void);
 
-int lsm6dso_ext_setup(enum sensor_ext_mode, const sensor_mag_t *mag, uint8_t mag_addr);
+int lsm6dso_ext_setup(sensor_ext_mode_t, const sensor_mag_t *mag, uint8_t mag_addr);
 
 int lsm6dso_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes);
 int lsm6dso_ext_write_read(const uint8_t addr, const uint8_t *write_buf, size_t num_write, uint8_t *read_buf, size_t num_read);

--- a/src/sensor/imu/LSM6DSO.h
+++ b/src/sensor/imu/LSM6DSO.h
@@ -68,11 +68,11 @@ int lsm6dso_init(float clock_rate, float accel_time, float gyro_time, float *acc
 void lsm6dso_update_fs(float accel_range, float gyro_range, float *accel_actual_range, float *gyro_actual_range);
 int lsm6dso_update_odr(float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time);
 
-uint16_t lsm6dso_fifo_read(uint8_t *data, uint16_t len);
+uint16_t lsm6dso_data_read(uint8_t *data, uint16_t len);
 
 uint8_t lsm6dso_setup_WOM(void);
 
-int lsm6dso_ext_setup(enum sensor_ext_mode);
+int lsm6dso_ext_setup(enum sensor_ext_mode, const sensor_mag_t *mag, uint8_t mag_addr);
 
 int lsm6dso_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes);
 int lsm6dso_ext_write_read(const uint8_t addr, const uint8_t *write_buf, size_t num_write, uint8_t *read_buf, size_t num_read);

--- a/src/sensor/imu/LSM6DSO.h
+++ b/src/sensor/imu/LSM6DSO.h
@@ -72,8 +72,7 @@ uint16_t lsm6dso_fifo_read(uint8_t *data, uint16_t len);
 
 uint8_t lsm6dso_setup_WOM(void);
 
-int lsm6dso_ext_setup(void);
-int lsm6dso_ext_passthrough(bool passthrough);
+int lsm6dso_ext_setup(enum sensor_ext_mode);
 
 int lsm6dso_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes);
 int lsm6dso_ext_write_read(const uint8_t addr, const uint8_t *write_buf, size_t num_write, uint8_t *read_buf, size_t num_read);

--- a/src/sensor/imu/LSM6DSO.h
+++ b/src/sensor/imu/LSM6DSO.h
@@ -76,7 +76,7 @@ int lsm6dso_ext_setup(void);
 int lsm6dso_ext_passthrough(bool passthrough);
 
 int lsm6dso_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes);
-int lsm6dso_ext_write_read(const uint8_t addr, const void *write_buf, size_t num_write, void *read_buf, size_t num_read);
+int lsm6dso_ext_write_read(const uint8_t addr, const uint8_t *write_buf, size_t num_write, uint8_t *read_buf, size_t num_read);
 
 extern const sensor_imu_t sensor_imu_lsm6dso;
 extern const sensor_ext_ssi_t sensor_ext_lsm6dso;

--- a/src/sensor/imu/LSM6DSV.c
+++ b/src/sensor/imu/LSM6DSV.c
@@ -366,7 +366,7 @@ int lsm_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes)
 	return err;
 }
 
-int lsm_ext_write_read(const uint8_t addr, const void *write_buf, size_t num_write, void *read_buf, size_t num_read)
+int lsm_ext_write_read(const uint8_t addr, const uint8_t *write_buf, size_t num_write, uint8_t *read_buf, size_t num_read)
 {
 	if (num_write != 1 || num_read < 1 || num_read > 8)
 	{

--- a/src/sensor/imu/LSM6DSV.c
+++ b/src/sensor/imu/LSM6DSV.c
@@ -306,34 +306,36 @@ uint8_t lsm_setup_WOM(void)
 	return NRF_GPIO_PIN_PULLUP << 4 | NRF_GPIO_PIN_SENSE_LOW; // active low
 }
 
-int lsm_ext_setup(void)
-{
-	// enable internal pull-up for auxiliary I2C
-	int err = ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_IF_CFG, 0x58); // SHUB_PU_EN, INT H_LACTIVE active low, PP_OD open-drain
-	if (err)
-		LOG_ERR("Communication error");
-	sensor_interface_ext_configure(&sensor_ext_lsm6dsv);
-	return 0;
-}
-
-int lsm_ext_passthrough(bool passthrough)
-{
+int lsm_ext_setup(enum sensor_ext_mode mode) {
 	int err = 0;
-	if (passthrough)
-	{
-		err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_FUNC_CFG_ACCESS, 0x40); // switch to sensor hub registers
-		err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_MASTER_CONFIG, 0x10); // passthrough on
-		err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_FUNC_CFG_ACCESS, 0x00); // switch to normal registers
+	switch (mode) {
+		case SENSOR_EXT_MODE_OFF:
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_FUNC_CFG_ACCESS, 0x40); // switch to sensor hub registers
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_MASTER_CONFIG, 0x00); // passthrough off
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_FUNC_CFG_ACCESS, 0x00); // switch to normal registers
+			break;
+
+		case SENSOR_EXT_MODE_I2C_PASSTHROUGH:
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_FUNC_CFG_ACCESS, 0x40); // switch to sensor hub registers
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_MASTER_CONFIG, 0x10); // passthrough on
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_FUNC_CFG_ACCESS, 0x00); // switch to normal registers
+			break;
+			
+		case SENSOR_EXT_MODE_I2CM_PROXY:
+			// enable internal pull-up for auxiliary I2C
+			err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_IF_CFG, 0x58); // SHUB_PU_EN, INT H_LACTIVE active low, PP_OD open-drain
+			sensor_interface_ext_configure(&sensor_ext_lsm6dsv);
+			break;
+		
+		case SENSOR_EXT_MODE_I2CM_AUTONOMOUS:
+			return -1;
 	}
-	else
-	{
-		err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_FUNC_CFG_ACCESS, 0x40); // switch to sensor hub registers
-		err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_MASTER_CONFIG, 0x00); // passthrough off
-		err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_FUNC_CFG_ACCESS, 0x00); // switch to normal registers
+
+	if (err) {
+		LOG_ERR("Communication error: %d", err);
 	}
-	if (err)
-		LOG_ERR("Communication error");
-	return 0;
+
+	return err;
 }
 
 int lsm_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes)
@@ -421,7 +423,6 @@ const sensor_imu_t sensor_imu_lsm6dsv = {
 	*lsm_setup_WOM,
 
 	*lsm_ext_setup,
-	*lsm_ext_passthrough
 };
 
 const sensor_ext_ssi_t sensor_ext_lsm6dsv = {

--- a/src/sensor/imu/LSM6DSV.c
+++ b/src/sensor/imu/LSM6DSV.c
@@ -205,7 +205,7 @@ uint16_t lsm_data_read(uint8_t *data, uint16_t len)
 	return total;
 }
 
-int lsm_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
+sensor_data_attrs_t lsm_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
 {
 	index *= PACKET_SIZE;
 	switch (data[index] >> 3)
@@ -216,18 +216,19 @@ int lsm_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], floa
 			a[i] = (int16_t)((((uint16_t)data[index + 2 + (i * 2)]) << 8) | data[index + 1 + (i * 2)]);
 			a[i] *= accel_sensitivity;
 		}
-		return 0;
+		return DATA_VALID_ACCEL;
 	case 0x01: // Gyroscope NC (Gyroscope uncompressed data)
 		for (int i = 0; i < 3; i++) // x, y, z
 		{
 			g[i] = (int16_t)((((uint16_t)data[index + 2 + (i * 2)]) << 8) | data[index + 1 + (i * 2)]);
 			g[i] *= gyro_sensitivity;
+			
 		}
-		return 0;
+		return DATA_VALID_GYRO;
 	default:
 	}
 	// TODO: need to skip invalid data
-	return 1;
+	return DATA_INVALID;
 }
 
 void lsm_accel_read(float a[3])
@@ -306,7 +307,7 @@ uint8_t lsm_setup_WOM(void)
 	return NRF_GPIO_PIN_PULLUP << 4 | NRF_GPIO_PIN_SENSE_LOW; // active low
 }
 
-int lsm_ext_setup(enum sensor_ext_mode mode, const sensor_mag_t *mag, uint8_t mag_addr) {
+int lsm_ext_setup(sensor_ext_mode_t mode, const sensor_mag_t *mag, uint8_t mag_addr) {
 	int err = 0;
 	switch (mode) {
 		case SENSOR_EXT_MODE_OFF:

--- a/src/sensor/imu/LSM6DSV.c
+++ b/src/sensor/imu/LSM6DSV.c
@@ -177,7 +177,7 @@ int lsm_update_odr(float accel_time, float gyro_time, float *accel_actual_time, 
 	return 0;
 }
 
-uint16_t lsm_fifo_read(uint8_t *data, uint16_t len)
+uint16_t lsm_data_read(uint8_t *data, uint16_t len)
 {
 	int err = 0;
 	uint16_t total = 0;
@@ -205,7 +205,7 @@ uint16_t lsm_fifo_read(uint8_t *data, uint16_t len)
 	return total;
 }
 
-int lsm_fifo_process(uint16_t index, uint8_t *data, float a[3], float g[3])
+int lsm_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
 {
 	index *= PACKET_SIZE;
 	switch (data[index] >> 3)
@@ -306,7 +306,7 @@ uint8_t lsm_setup_WOM(void)
 	return NRF_GPIO_PIN_PULLUP << 4 | NRF_GPIO_PIN_SENSE_LOW; // active low
 }
 
-int lsm_ext_setup(enum sensor_ext_mode mode) {
+int lsm_ext_setup(enum sensor_ext_mode mode, const sensor_mag_t *mag, uint8_t mag_addr) {
 	int err = 0;
 	switch (mode) {
 		case SENSOR_EXT_MODE_OFF:
@@ -413,8 +413,8 @@ const sensor_imu_t sensor_imu_lsm6dsv = {
 	*lsm_update_fs,
 	*lsm_update_odr,
 
-	*lsm_fifo_read,
-	*lsm_fifo_process,
+	*lsm_data_read,
+	*lsm_data_process,
 	*lsm_accel_read,
 	*lsm_gyro_read,
 	*lsm_temp_read,

--- a/src/sensor/imu/LSM6DSV.c
+++ b/src/sensor/imu/LSM6DSV.c
@@ -61,6 +61,8 @@ void lsm_shutdown(void)
 	int err = ssi_reg_write_byte(SENSOR_INTERFACE_DEV_IMU, LSM6DSV_CTRL3, 0x01); // SW_RESET
 	if (err)
 		LOG_ERR("Communication error");
+	// TODO : Correctly wait for the reset to finish
+	k_msleep(1);
 }
 
 void lsm_update_fs(float accel_range, float gyro_range, float *accel_actual_range, float *gyro_actual_range)

--- a/src/sensor/imu/LSM6DSV.h
+++ b/src/sensor/imu/LSM6DSV.h
@@ -111,8 +111,7 @@ int lsm_temp_read(float *data);
 uint8_t lsm_setup_DRDY(uint16_t threshold);
 uint8_t lsm_setup_WOM(void);
 
-int lsm_ext_setup(void);
-int lsm_ext_passthrough(bool passthrough);
+int lsm_ext_setup(enum sensor_ext_mode);
 
 int lsm_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes);
 int lsm_ext_write_read(const uint8_t addr, const uint8_t *write_buf, size_t num_write, uint8_t *read_buf, size_t num_read);

--- a/src/sensor/imu/LSM6DSV.h
+++ b/src/sensor/imu/LSM6DSV.h
@@ -115,7 +115,7 @@ int lsm_ext_setup(void);
 int lsm_ext_passthrough(bool passthrough);
 
 int lsm_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes);
-int lsm_ext_write_read(const uint8_t addr, const void *write_buf, size_t num_write, void *read_buf, size_t num_read);
+int lsm_ext_write_read(const uint8_t addr, const uint8_t *write_buf, size_t num_write, uint8_t *read_buf, size_t num_read);
 
 extern const sensor_imu_t sensor_imu_lsm6dsv;
 extern const sensor_ext_ssi_t sensor_ext_lsm6dsv;

--- a/src/sensor/imu/LSM6DSV.h
+++ b/src/sensor/imu/LSM6DSV.h
@@ -103,7 +103,7 @@ void lsm_update_fs(float accel_range, float gyro_range, float *accel_actual_rang
 int lsm_update_odr(float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time);
 
 uint16_t lsm_data_read(uint8_t *data, uint16_t len);
-int lsm_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3]);
+sensor_data_attrs_t lsm_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3]);
 void lsm_accel_read(float a[3]);
 void lsm_gyro_read(float g[3]);
 int lsm_temp_read(float *data);
@@ -111,7 +111,7 @@ int lsm_temp_read(float *data);
 uint8_t lsm_setup_DRDY(uint16_t threshold);
 uint8_t lsm_setup_WOM(void);
 
-int lsm_ext_setup(enum sensor_ext_mode, const sensor_mag_t *mag, uint8_t mag_addr);
+int lsm_ext_setup(sensor_ext_mode_t, const sensor_mag_t *mag, uint8_t mag_addr);
 
 int lsm_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes);
 int lsm_ext_write_read(const uint8_t addr, const uint8_t *write_buf, size_t num_write, uint8_t *read_buf, size_t num_read);

--- a/src/sensor/imu/LSM6DSV.h
+++ b/src/sensor/imu/LSM6DSV.h
@@ -102,8 +102,8 @@ void lsm_shutdown(void);
 void lsm_update_fs(float accel_range, float gyro_range, float *accel_actual_range, float *gyro_actual_range);
 int lsm_update_odr(float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time);
 
-uint16_t lsm_fifo_read(uint8_t *data, uint16_t len);
-int lsm_fifo_process(uint16_t index, uint8_t *data, float a[3], float g[3]);
+uint16_t lsm_data_read(uint8_t *data, uint16_t len);
+int lsm_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3]);
 void lsm_accel_read(float a[3]);
 void lsm_gyro_read(float g[3]);
 int lsm_temp_read(float *data);
@@ -111,7 +111,7 @@ int lsm_temp_read(float *data);
 uint8_t lsm_setup_DRDY(uint16_t threshold);
 uint8_t lsm_setup_WOM(void);
 
-int lsm_ext_setup(enum sensor_ext_mode);
+int lsm_ext_setup(enum sensor_ext_mode, const sensor_mag_t *mag, uint8_t mag_addr);
 
 int lsm_ext_write(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes);
 int lsm_ext_write_read(const uint8_t addr, const uint8_t *write_buf, size_t num_write, uint8_t *read_buf, size_t num_read);

--- a/src/sensor/interface.c
+++ b/src/sensor/interface.c
@@ -142,6 +142,9 @@ static inline int ssi_write(enum sensor_interface_dev dev, const uint8_t *buf, u
 #endif
 	case SENSOR_INTERFACE_SPEC_I2C:
 		return i2c_write_dt(sensor_interface_dev_i2c[dev], buf, num_bytes);
+	case SENSOR_INTERFACE_SPEC_EXT:
+		if (ext_ssi != NULL)
+			return ext_ssi->ext_write(ext_addr, buf, num_bytes);
 	default:
 		return -1;
 	}
@@ -177,9 +180,6 @@ static inline int ssi_read(enum sensor_interface_dev dev, uint8_t *buf, uint32_t
 #endif
 	case SENSOR_INTERFACE_SPEC_I2C:
 		return i2c_read_dt(sensor_interface_dev_i2c[dev], buf, num_bytes);
-	case SENSOR_INTERFACE_SPEC_EXT:
-		if (ext_ssi != NULL)
-			return ext_ssi->ext_write(ext_addr, buf, num_bytes);
 	default:
 		return -1;
 	}

--- a/src/sensor/interface.c
+++ b/src/sensor/interface.c
@@ -185,7 +185,7 @@ static inline int ssi_read(enum sensor_interface_dev dev, uint8_t *buf, uint32_t
 	}
 }
 
-static inline int ssi_write_read(enum sensor_interface_dev dev, const void *write_buf, size_t num_write, void *read_buf, size_t num_read)
+static inline int ssi_write_read(enum sensor_interface_dev dev, const uint8_t *write_buf, size_t num_write, uint8_t *read_buf, size_t num_read)
 {
 	// TODO: is separate read/write better for spi?
 	switch (sensor_interface_dev_spec[dev])

--- a/src/sensor/interface.h
+++ b/src/sensor/interface.h
@@ -66,4 +66,31 @@ int ssi_reg_update_byte(enum sensor_interface_dev dev, uint8_t reg_addr, uint8_t
 int ssi_reg_read_interval(enum sensor_interface_dev dev, uint8_t start_addr, uint8_t *buf, uint32_t num_bytes, uint32_t interval);
 int ssi_burst_read_interval(enum sensor_interface_dev dev, uint8_t start_addr, uint8_t *buf, uint32_t num_bytes, uint32_t interval);
 
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(imu_spi), okay)
+#define SENSOR_IMU_SPI_EXISTS true
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(imu), okay)
+#define SENSOR_IMU_EXISTS true
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(mag_spi), okay)
+#define SENSOR_MAG_SPI_EXISTS true
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(mag), okay)
+#define SENSOR_DIRECT_MAG_EXISTS true
+#endif
+
+#if SENSOR_IMU_SPI_EXISTS // might exist
+#define SENSOR_MAG_EXT_EXISTS true
+#endif
+
+#if !SENSOR_MAG_SPI_EXISTS && !SENSOR_DIRECT_MAG_EXISTS && !SENSOR_MAG_EXT_EXISTS
+#define SENSOR_MAG_EXISTS false
+#else
+#define SENSOR_MAG_EXISTS true
+#endif
+
 #endif

--- a/src/sensor/interface.h
+++ b/src/sensor/interface.h
@@ -42,7 +42,7 @@ enum sensor_interface_spec
 
 typedef struct sensor_ext_ssi {
 	int (*ext_write)(const uint8_t addr, const uint8_t *buf, uint32_t num_bytes);
-	int (*ext_write_read)(const uint8_t addr, const void *write_buf, size_t num_write, void *read_buf, size_t num_read);
+	int (*ext_write_read)(const uint8_t addr, const uint8_t *write_buf, size_t num_write, uint8_t *read_buf, size_t num_read);
 	uint8_t ext_burst;
 } sensor_ext_ssi_t;
 

--- a/src/sensor/mag/AK09940.c
+++ b/src/sensor/mag/AK09940.c
@@ -7,6 +7,7 @@
 static const float sensitivity = 10; // nT/LSB
 
 static uint8_t last_odr = 0xff;
+static float last_real_time = 0.0f;
 //static uint8_t last_rawTemp = 0xff;
 static int64_t oneshot_trigger_time = 0;
 
@@ -25,6 +26,11 @@ void ak_shutdown(void)
 	int err = ssi_reg_write_byte(SENSOR_INTERFACE_DEV_MAG, AK09940_CNTL4, 0x01);
 	if (err)
 		LOG_ERR("Communication error");
+}
+
+float ak_get_odr(void)
+{
+	return last_real_time;
 }
 
 int ak_update_odr(float time, float *actual_time)
@@ -91,6 +97,7 @@ int ak_update_odr(float time, float *actual_time)
 		LOG_ERR("Communication error");
 
 	*actual_time = time;
+	last_real_time = time;
 	return err;
 }
 
@@ -152,11 +159,12 @@ const sensor_mag_t sensor_mag_ak09940 = {
 	*ak_shutdown,
 
 	*ak_update_odr,
+	*ak_get_odr,
 
 	*ak_mag_oneshot,
 	*ak_mag_read,
 	*ak_temp_read,
 
 	*ak_mag_process,
-	9, 9
+	9, 9, 0, AK09940_HXL
 };

--- a/src/sensor/mag/BMM150.c
+++ b/src/sensor/mag/BMM150.c
@@ -54,6 +54,7 @@ static int8_t dig_xy2;
 static uint16_t dig_xyz1;
 
 static uint8_t last_odr = 0xff;
+static float last_real_time = 0.0f;
 
 LOG_MODULE_REGISTER(BMM150, LOG_LEVEL_DBG);
 
@@ -81,6 +82,11 @@ void bmm1_shutdown(void)
 	int err = ssi_reg_write_byte(SENSOR_INTERFACE_DEV_MAG, BMM150_POWER_CTRL, 0x00);
 	if (err)
 		LOG_ERR("Communication error");
+}
+
+float bmm1_get_odr(void)
+{
+	return last_real_time;
 }
 
 int bmm1_update_odr(float time, float *actual_time)
@@ -174,6 +180,7 @@ int bmm1_update_odr(float time, float *actual_time)
 		LOG_ERR("Communication error");
 
 	*actual_time = time;
+	last_real_time = time;
 	return err;
 }
 
@@ -303,11 +310,13 @@ const sensor_mag_t sensor_mag_bmm150 = {
 	*bmm1_shutdown,
 
 	*bmm1_update_odr,
+	*bmm1_get_odr,
 
 	*bmm1_mag_oneshot,
 	*bmm1_mag_read,
 	*mag_none_temp_read,
 
 	*bmm1_mag_process,
-	6, 8 // rhall does not get read by limited external interface
+	6, 8, // rhall does not get read by limited external interface
+	0, BMM150_DATAX_LSB
 };

--- a/src/sensor/mag/BMM350.c
+++ b/src/sensor/mag/BMM350.c
@@ -54,6 +54,7 @@ static const float sensitivity_z = (power / (bz_sens * ina_z_gain_trgt * adc_gai
 static const float sensitivity_temp = 1 / (temp_sens * adc_gain * lut_gain * 1048576); // C/LSB
 
 static uint8_t last_odr = 0xff;
+static float last_real_time = 0.0f;
 
 LOG_MODULE_REGISTER(BMM350, LOG_LEVEL_DBG);
 
@@ -71,6 +72,11 @@ void bmm3_shutdown(void)
 	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_MAG, BMM350_PMU_CMD, PMU_CMD_SUS); // enter suspend (amogus,)
 	if (err)
 		LOG_ERR("Communication error");
+}
+
+float bmm3_get_odr(void)
+{
+	return last_real_time;
 }
 
 int bmm3_update_odr(float time, float *actual_time)
@@ -170,6 +176,7 @@ int bmm3_update_odr(float time, float *actual_time)
 		LOG_ERR("Communication error");
 
 	*actual_time = time;
+	last_real_time = time;
 	return err;
 }
 
@@ -226,11 +233,12 @@ const sensor_mag_t sensor_mag_bmm350 = {
 	*bmm3_shutdown,
 
 	*bmm3_update_odr,
+	*bmm3_get_odr,
 
 	*bmm3_mag_oneshot,
 	*bmm3_mag_read,
 	*bmm3_temp_read,
 
 	*bmm3_mag_process,
-	9, 9
+	9, 9, 2, BMM350_MAG_X_XLSB
 };

--- a/src/sensor/mag/IST8306.c
+++ b/src/sensor/mag/IST8306.c
@@ -8,6 +8,7 @@
 static const float sensitivity = 0.3; // uT/LSB
 
 static uint8_t last_odr = 0xff;
+static float last_real_time = 0.0f;
 static int64_t oneshot_trigger_time = 0;
 
 LOG_MODULE_REGISTER(IST8306, LOG_LEVEL_DBG);
@@ -27,6 +28,11 @@ void ist8306_shutdown(void)
 //	int err = ssi_reg_write_byte(SENSOR_INTERFACE_DEV_MAG, IST8306_ACTR, 0x02); // suspend
 	if (err)
 		LOG_ERR("Communication error");
+}
+
+float ist8306_get_odr(void)
+{
+	return last_real_time;
 }
 
 int ist8306_update_odr(float time, float *actual_time)
@@ -110,6 +116,7 @@ int ist8306_update_odr(float time, float *actual_time)
 		LOG_ERR("Communication error");
 
 	*actual_time = time;
+	last_real_time = time;
 	return err;
 }
 
@@ -155,11 +162,12 @@ const sensor_mag_t sensor_mag_ist8306 = {
 	*ist8306_shutdown,
 
 	*ist8306_update_odr,
+	*ist8306_get_odr,
 
 	*ist8306_mag_oneshot,
 	*ist8306_mag_read,
 	*mag_none_temp_read,
 
 	*ist8306_mag_process,
-	6, 6
+	6, 6, 0, IST8306_DATAXL
 };

--- a/src/sensor/mag/IST8308.c
+++ b/src/sensor/mag/IST8308.c
@@ -9,6 +9,7 @@
 static const float sensitivity = 0.075; // uT/LSB
 
 static uint8_t last_odr = 0xff;
+static float last_real_time = 0.0f;
 static int64_t oneshot_trigger_time = 0;
 
 LOG_MODULE_REGISTER(IST8308, LOG_LEVEL_DBG);
@@ -29,6 +30,11 @@ void ist8308_shutdown(void)
 //	int err = ssi_reg_write_byte(SENSOR_INTERFACE_DEV_MAG, IST8306_ACTR, 0x02); // suspend
 	if (err)
 		LOG_ERR("Communication error");
+}
+
+float ist8308_get_odr(void)
+{
+	return last_real_time;
 }
 
 int ist8308_update_odr(float time, float *actual_time)
@@ -112,6 +118,7 @@ int ist8308_update_odr(float time, float *actual_time)
 		LOG_ERR("Communication error");
 
 	*actual_time = time;
+	last_real_time = time;
 	return err;
 }
 
@@ -157,11 +164,12 @@ const sensor_mag_t sensor_mag_ist8308 = {
 	*ist8308_shutdown,
 
 	*ist8308_update_odr,
+	*ist8308_get_odr,
 
 	*ist8308_mag_oneshot,
 	*ist8308_mag_read,
 	*mag_none_temp_read,
 
 	*ist8308_mag_process,
-	6, 6
+	6, 6, 0, IST8306_DATAXL
 };

--- a/src/sensor/mag/LIS2MDL.c
+++ b/src/sensor/mag/LIS2MDL.c
@@ -8,6 +8,7 @@
 static const float sensitivity = 1.5 / 1000; // ~1.5 mgauss/LSB -> 0.0015 G/LSB
 
 static uint8_t last_odr = 0xff;
+static float last_real_time = 0.0f;
 
 LOG_MODULE_REGISTER(LIS2MDL, LOG_LEVEL_DBG);
 
@@ -25,6 +26,11 @@ void lis2_shutdown(void)
 	int err = ssi_reg_write_byte(SENSOR_INTERFACE_DEV_MAG, LIS2MDL_CFG_REG_A, 0x20);
 	if (err)
 		LOG_ERR("Communication error");
+}
+
+float lis2_get_odr(void)
+{
+	return last_real_time;
 }
 
 int lis2_update_odr(float time, float *actual_time)
@@ -92,6 +98,7 @@ int lis2_update_odr(float time, float *actual_time)
 		LOG_ERR("Communication error");
 
 	*actual_time = time;
+	last_real_time = time;
 	return err;
 }
 
@@ -145,11 +152,12 @@ const sensor_mag_t sensor_mag_lis2mdl = {
 	*lis2_shutdown,
 
 	*lis2_update_odr,
+	*lis2_get_odr,
 
 	*lis2_mag_oneshot,
 	*lis2_mag_read,
 	*lis2_temp_read,
 
 	*lis2_mag_process,
-	6, 6
+	6, 6, 0, LIS2MDL_OUTX_L_REG
 };

--- a/src/sensor/mag/LIS3MDL.c
+++ b/src/sensor/mag/LIS3MDL.c
@@ -7,6 +7,7 @@
 static const float sensitivity = 1.0 / 3421; // Always 8G (FS = ±8 gauss: 3421 LSB/Gauss)
 
 static uint8_t last_odr = 0xff;
+static float last_real_time = 0.0f;
 
 LOG_MODULE_REGISTER(LIS3MDL, LOG_LEVEL_DBG);
 
@@ -27,6 +28,11 @@ void lis3_shutdown(void)
 	int err = ssi_reg_write_byte(SENSOR_INTERFACE_DEV_MAG, LIS3MDL_CTRL_REG2, 0x04);
 	if (err)
 		LOG_ERR("Communication error");
+}
+
+float lis3_get_odr(void)
+{
+	return last_real_time;
 }
 
 int lis3_update_odr(float time, float *actual_time)
@@ -144,6 +150,7 @@ int lis3_update_odr(float time, float *actual_time)
 		LOG_ERR("Communication error");
 
 	*actual_time = time;
+	last_real_time = time;
 	return err;
 }
 
@@ -197,11 +204,12 @@ const sensor_mag_t sensor_mag_lis3mdl = {
 	*lis3_shutdown,
 
 	*lis3_update_odr,
+	*lis3_get_odr,
 
 	*lis3_mag_oneshot,
 	*lis3_mag_read,
 	*lis3_temp_read,
 
 	*lis3_mag_process,
-	6, 6
+	6, 6, 0, LIS3MDL_OUT_X_L
 };

--- a/src/sensor/mag/MMC5983MA.c
+++ b/src/sensor/mag/MMC5983MA.c
@@ -19,6 +19,7 @@ static const float offset = 131072.0f; // mag range unsigned to signed
 
 static uint8_t last_odr = 0xff;
 static float last_time = 0;
+static float last_real_time = 0.0f;
 static uint8_t last_rawTemp = 0xff;
 static int64_t oneshot_trigger_time = 0;
 static bool auto_set_reset = true;
@@ -50,6 +51,11 @@ void mmc_shutdown(void)
 	int err = ssi_reg_write_byte(SENSOR_INTERFACE_DEV_MAG, MMC5983MA_CONTROL_1, 0x80); // Don't need to wait for MMC to finish reset
 	if (err)
 		LOG_ERR("Communication error");
+}
+
+float mmc_get_odr(void)
+{
+	return last_real_time;
 }
 
 int mmc_update_odr(float time, float *actual_time)
@@ -129,6 +135,7 @@ int mmc_update_odr(float time, float *actual_time)
 		LOG_ERR("Communication error");
 
 	*actual_time = time;
+	last_real_time = time;
 	return err;
 }
 
@@ -237,11 +244,13 @@ const sensor_mag_t sensor_mag_mmc5983ma = {
 	*mmc_shutdown,
 
 	*mmc_update_odr,
+	*mmc_get_odr,
 
 	*mmc_mag_oneshot,
 	*mmc_mag_read,
 	*mmc_temp_read,
 
 	*mmc_mag_process,
-	6, 7 // if only reading 6 bytes, the data will be lower precision
+	6, 7, // if only reading 6 bytes, the data will be lower precision
+	0, MMC5983MA_XOUT_0
 };

--- a/src/sensor/mag/QMC6309.c
+++ b/src/sensor/mag/QMC6309.c
@@ -64,6 +64,7 @@ static const float sensitivity = 1 / 4000.0f; // ~0.25 mgauss/LSB @ 8G range -> 
 static uint8_t last_state = 0xff;
 static bool lastOvfl = false;
 static int64_t oneshot_trigger_time = 0;
+static float last_real_time = 0.0f;
 
 LOG_MODULE_REGISTER(QMC6309, LOG_LEVEL_INF);
 
@@ -82,6 +83,11 @@ void qmc_shutdown(void)
 	err |= ssi_reg_write_byte(SENSOR_INTERFACE_DEV_MAG, QMC6309_CTRL_REG_2, SOFT_RESET_CLEAR);
 	if (err)
 		LOG_ERR("Communication error");
+}
+
+float qmc_get_odr(void)
+{
+	return last_real_time;
 }
 
 int qmc_update_odr(float time, float *actual_time)
@@ -145,6 +151,8 @@ int qmc_update_odr(float time, float *actual_time)
 	oneshot_trigger_time = 0;
 
 	*actual_time = time;
+	last_real_time = time;
+
 	return err;
 }
 
@@ -207,11 +215,12 @@ const sensor_mag_t sensor_mag_qmc6309 = {
 	*qmc_shutdown,
 
 	*qmc_update_odr,
+	*qmc_get_odr,
 
 	*qmc_mag_oneshot,
 	*qmc_mag_read,
 	*mag_none_temp_read,
 
 	*qmc_mag_process,
-	6, 6
+	6, 6, 0, QMC6309_OUTX_L_REG
 };

--- a/src/sensor/mag/QMC6309.c
+++ b/src/sensor/mag/QMC6309.c
@@ -97,7 +97,7 @@ int qmc_update_odr(float time, float *actual_time)
 	}
 	else
 	{
-		MD = MD_CONTINUOUS;
+		MD = MD_NORMAL;
 		ODR = 1 / time;
 	}
 
@@ -161,16 +161,18 @@ void qmc_mag_read(float m[3])
 	int err = 0;
 	uint8_t status = 0; // Always check DRDY
 	int64_t timeout = (oneshot_trigger_time ? oneshot_trigger_time : k_uptime_get()) + 2; // 2ms timeout
-	while ((status & STAT_DATA_RDY_MASK) == 0) // wait for data ready flag
-	{
-		err |= ssi_reg_read_byte(SENSOR_INTERFACE_DEV_MAG, QMC6309_STAT_REG, &status);
-		if(k_uptime_get() > timeout)
-		{
-			LOG_WRN("Data ready status timeout!");
-			break;
-		}
-	}
 	oneshot_trigger_time = 0;
+
+	do {
+		err |= ssi_reg_read_byte(SENSOR_INTERFACE_DEV_MAG, QMC6309_STAT_REG, &status);
+	}
+	while((status & STAT_DATA_RDY_MASK) == 0 && k_uptime_get() <= timeout);
+	
+	if ((status & STAT_DATA_RDY_MASK) == 0) {
+		LOG_WRN("Data not ready");
+		return;
+	}
+
 	if (status & STAT_OVERFLOW_MASK) // check overflow flag
 	{
 		if (lastOvfl == 0)

--- a/src/sensor/sensor.c
+++ b/src/sensor/sensor.c
@@ -695,10 +695,13 @@ int sensor_init(void)
 // 55-66ms to wait, get chip ids, and setup icm (50ms spent waiting for accel and gyro to start)
 	if (mag_available && mag_enabled)
 	{
-		// TODO: need to flag passthrough enabled
-//			sensor_imu->ext_passthrough(true); // reenable passthrough
+#if SENSOR_MAG_EXISTS
+		sensor_imu->ext_passthrough(true); // reenable passthrough
+#elif SENSOR_MAG_EXT_EXISTS
+		sensor_imu->ext_setup();
+#endif
 		err = sensor_mag->init(mag_initial_time, &mag_actual_time);
-		mag_interval = mag_actual_time * 0.9f * 1000; // start attemping magnetometer reads before expected new sample
+		mag_interval = mag_actual_time * 1000 - 2; // start attemping magnetometer reads before expected new sample, ask for each sample 2ms earlier
 #if SENSOR_MAG_SPI_EXISTS
 		LOG_INF("Requested SPI frequency: %.2fMHz", (double)sensor_mag_spi_dev.config.frequency / 1000000.0);
 #endif

--- a/src/sensor/sensor.c
+++ b/src/sensor/sensor.c
@@ -918,11 +918,12 @@ void sensor_loop(void)
 			{
 				float raw_a[3] = {0};
 				float raw_g[3] = {0};
-				if (sensor_imu->data_process(i, raw_data, raw_a, raw_g, raw_m))
+				sensor_data_attrs_t attrs = sensor_imu->data_process(i, raw_data, raw_a, raw_g, raw_m);
+				if (attrs & DATA_INVALID)
 					continue; // skip on error
 
 				// TODO: split into separate functions
-				if (raw_g[0] != 0 || raw_g[1] != 0 || raw_g[2] != 0)
+				if (attrs & DATA_VALID_GYRO)
 				{
 #if DEBUG
 					if (valid_acquisition)
@@ -956,7 +957,7 @@ void sensor_loop(void)
 					}
 				}
 
-				if (raw_a[0] != 0 || raw_a[1] != 0 || raw_a[2] != 0)
+				if (attrs & DATA_VALID_ACCEL)
 				{
 #if DEBUG
 					if (valid_acquisition)
@@ -983,7 +984,7 @@ void sensor_loop(void)
 					a_count++;
 				}
 
-				if (raw_m[0] != 0 || raw_m[1] != 0 || raw_m[2] != 0)
+				if (attrs & DATA_VALID_MAG)
 				{
 					mag_read = true;
 				}
@@ -1156,7 +1157,7 @@ void sensor_loop(void)
 		}
 		else // if signal was sent during processing, loop immediately to catch up (I2C could cause this to happen constantly)
 		{
-			LOG_DBG("FIFO THS/WM/WTM triggered during loop");
+			LOG_DBG("Interrupt triggered during loop");
 			k_yield();
 			main_wfi = false;
 		}

--- a/src/sensor/sensor.c
+++ b/src/sensor/sensor.c
@@ -107,6 +107,7 @@ static bool main_suspended;
 
 static bool mag_available;
 static bool mag_enabled; // TODO: toggle from server
+static bool mag_manual;
 
 static int fusion_id = 0;
 static const sensor_fusion_t *sensor_fusion = &sensor_fusion_none;
@@ -313,7 +314,7 @@ int sensor_scan(void)
 	if (mag_id < 0 && (sensor_imu_dev_reg & 0x80)) // SPI IMU
 	{
 		// IMU may support I2CM if the magnetometer is connected through the IMU
-		int err = sensor_imu->ext_setup(SENSOR_EXT_MODE_I2CM_PROXY);
+		int err = sensor_imu->ext_setup(SENSOR_EXT_MODE_I2CM_PROXY, NULL, 0);
 		if (!err)
 		{
 			LOG_INF("Scanning bus for magnetometer through IMU I2CM");
@@ -544,7 +545,7 @@ static void set_update_time_ms(int time_ms)
 	sensor_update_time_ms = time_ms; // TODO: terrible naming
 }
 
-bool main_wfi = false;
+volatile bool main_wfi = false;
 
 static void sensor_interrupt_handler(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
 {
@@ -700,12 +701,22 @@ int sensor_init(void)
 	if (mag_available && mag_enabled)
 	{
 #if SENSOR_DIRECT_MAG_EXISTS
-		sensor_imu->ext_setup(SENSOR_EXT_MODE_I2C_PASSTHROUGH); // reenable passthrough
+		sensor_imu->ext_setup(SENSOR_EXT_MODE_I2C_PASSTHROUGH, NULL); // reenable passthrough
 #elif SENSOR_MAG_EXT_EXISTS
-		sensor_imu->ext_setup(SENSOR_EXT_MODE_I2CM_PROXY); // todo, autonomous if possible
+		sensor_imu->ext_setup(SENSOR_EXT_MODE_I2CM_PROXY, NULL, sensor_mag_dev.addr & 0x7F);
 #endif
 		err = sensor_mag->init(mag_initial_time, &mag_actual_time);
 		mag_interval = mag_actual_time * 1000 - 2; // start attemping magnetometer reads before expected new sample, ask for each sample 2ms earlier
+		mag_manual = true;
+
+#if SENSOR_MAG_EXT_EXISTS
+		// try to switch to autonomous mode
+		if (sensor_imu->ext_setup(SENSOR_EXT_MODE_I2CM_AUTONOMOUS, sensor_mag, sensor_mag_dev.addr & 0x7F) == 0) {
+			// switched to autonomous, no need to handle mag manually
+			mag_manual = false;
+		}
+#endif
+
 #if SENSOR_MAG_SPI_EXISTS
 		LOG_INF("Requested SPI frequency: %.2fMHz", (double)sensor_mag_spi_dev.config.frequency / 1000000.0);
 #endif
@@ -837,7 +848,7 @@ void sensor_loop(void)
 				connection_update_sensor_temp(temp);
 			}
 
-			// Read gyroscope (FIFO)
+			// Read IMU (FIFO)
 			uint16_t data_size = CONFIG_1_SETTINGS_READ(CONFIG_1_SENSOR_USE_LOW_POWER_2) ? 1900 : 1024; // Limit FIFO read to 2048 bytes (worst case is ICM 20 byte packet at 1000Hz and 100ms update time)
 			uint8_t* raw_data = (uint8_t*)k_malloc(data_size);
 			if (raw_data == NULL)
@@ -846,7 +857,7 @@ void sensor_loop(void)
 				set_status(SYS_STATUS_SENSOR_ERROR, true);
 				main_ok = false;
 			}
-			uint16_t packets = sensor_imu->fifo_read(raw_data, data_size); // TODO: name this better?
+			uint16_t packets = sensor_imu->data_read(raw_data, data_size); // TODO: name this better?
 
 			// Debug info
 #if DEBUG
@@ -860,10 +871,10 @@ void sensor_loop(void)
 			last_acquisition_time = acquisition_time;
 #endif
 
-			// Read magnetometer
+			// Read magnetometer, if in manual mode
 			float raw_m[3];
 			bool mag_read = false;
-			if (mag_available && mag_enabled && (k_uptime_get() - last_mag_time > mag_interval)) // some magnetometer do not have int pin // TODO: implement for magnetometer that does, or read status byte
+			if (mag_manual && (k_uptime_get() - last_mag_time > mag_interval)) // some magnetometer do not have int pin // TODO: implement for magnetometer that does, or read status byte
 			{
 				mag_read = true;
 				sensor_mag->mag_read(raw_m); // reading mag last, and it will be processed last
@@ -907,7 +918,7 @@ void sensor_loop(void)
 			{
 				float raw_a[3] = {0};
 				float raw_g[3] = {0};
-				if (sensor_imu->fifo_process(i, raw_data, raw_a, raw_g))
+				if (sensor_imu->data_process(i, raw_data, raw_a, raw_g, raw_m))
 					continue; // skip on error
 
 				// TODO: split into separate functions
@@ -972,6 +983,11 @@ void sensor_loop(void)
 					a_count++;
 				}
 
+				if (raw_m[0] != 0 || raw_m[1] != 0 || raw_m[2] != 0)
+				{
+					mag_read = true;
+				}
+
 				processed_packets++;
 			}
 
@@ -986,7 +1002,7 @@ void sensor_loop(void)
 				total_processed_packets += processed_packets;
 #endif
 
-			if (mag_available && mag_enabled && mag_read && memcmp(raw_m, last_m, sizeof(last_m))) // check data has changed from last acquisition
+			if (mag_read && memcmp(raw_m, last_m, sizeof(last_m))) // check data has changed from last acquisition
 			{
 #if DEBUG
 				total_mag_samples++;

--- a/src/sensor/sensor.c
+++ b/src/sensor/sensor.c
@@ -36,41 +36,41 @@
 
 #define SPI_OP SPI_MODE_CPOL | SPI_MODE_CPHA | SPI_WORD_SET(8)
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(imu_spi), okay)
-#define SENSOR_IMU_SPI_EXISTS true
+#if SENSOR_IMU_SPI_EXISTS
 #define SENSOR_IMU_SPI_NODE DT_NODELABEL(imu_spi)
 static struct spi_dt_spec sensor_imu_spi_dev = SPI_DT_SPEC_GET(SENSOR_IMU_SPI_NODE, SPI_OP, 0);
 #endif
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(imu), okay)
-#define SENSOR_IMU_EXISTS true
+
+
+#if SENSOR_IMU_EXISTS
 #define SENSOR_IMU_NODE DT_NODELABEL(imu)
 static struct i2c_dt_spec sensor_imu_dev = I2C_DT_SPEC_GET(SENSOR_IMU_NODE);
 #else
 static struct i2c_dt_spec sensor_imu_dev = {0};
 #endif
+
 #if !SENSOR_IMU_SPI_EXISTS && !SENSOR_IMU_EXISTS
 #error "IMU node does not exist"
 #endif
 static uint8_t sensor_imu_dev_reg = 0xFF;
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(mag_spi), okay)
-#define SENSOR_MAG_SPI_EXISTS true
+#if SENSOR_MAG_SPI_EXISTS
 #define SENSOR_MAG_SPI_NODE DT_NODELABEL(mag_spi)
 static struct spi_dt_spec sensor_mag_spi_dev = SPI_DT_SPEC_GET(SENSOR_MAG_SPI_NODE, SPI_OP, 0);
 #endif
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(mag), okay)
-#define SENSOR_MAG_EXISTS true
+
+
+#if SENSOR_DIRECT_MAG_EXISTS
 #define SENSOR_MAG_NODE DT_NODELABEL(mag)
 static struct i2c_dt_spec sensor_mag_dev = I2C_DT_SPEC_GET(SENSOR_MAG_NODE);
 #else
 static struct i2c_dt_spec sensor_mag_dev = {0};
 #endif
-#if SENSOR_IMU_SPI_EXISTS // might exist
-#define SENSOR_MAG_EXT_EXISTS true
+
+#if !SENSOR_MAG_EXISTS
+#warning "Magnetometer does not exist"
 #endif
-#if !SENSOR_MAG_SPI_EXISTS && !SENSOR_MAG_EXISTS && !SENSOR_MAG_EXT_EXISTS
-#warning "Magnetometer node does not exist"
-#endif
+
 static uint8_t sensor_mag_dev_reg = 0xFF;
 
 static float q[4] = {1.0f, 0.0f, 0.0f, 0.0f}; // vector to hold quaternion
@@ -276,7 +276,7 @@ int sensor_scan(void)
 	if (mag_id >= 0)
 		sensor_interface_register_sensor_mag_spi(&sensor_mag_spi_dev);
 #endif
-#if SENSOR_MAG_EXISTS
+#if SENSOR_DIRECT_MAG_EXISTS
 	if (mag_id < 0)
 	{
 		LOG_INF("Scanning bus for magnetometer");
@@ -287,7 +287,7 @@ int sensor_scan(void)
 	if (mag_id < 0 && !(sensor_imu_dev_reg & 0x80)) // I2C IMU
 	{
 		// IMU may support passthrough mode if the magnetometer is connected through the IMU
-		int err = sensor_imu->ext_passthrough(true); // no need to disable, the imu will be reset later
+		int err = sensor_imu->ext_passthrough(SENSOR_EXT_MODE_I2C_PASSTHROUGH); // no need to disable, the imu will be reset later
 		if (!err)
 		{
 			LOG_INF("Scanning bus for magnetometer through IMU passthrough");
@@ -313,7 +313,7 @@ int sensor_scan(void)
 	if (mag_id < 0 && (sensor_imu_dev_reg & 0x80)) // SPI IMU
 	{
 		// IMU may support I2CM if the magnetometer is connected through the IMU
-		int err = sensor_imu->ext_setup();
+		int err = sensor_imu->ext_setup(SENSOR_EXT_MODE_I2CM_PROXY);
 		if (!err)
 		{
 			LOG_INF("Scanning bus for magnetometer through IMU I2CM");
@@ -340,7 +340,7 @@ int sensor_scan(void)
 		}
 	}
 #endif
-#if !SENSOR_MAG_SPI_EXISTS && !SENSOR_MAG_EXISTS && !SENSOR_MAG_EXT_EXISTS
+#if !SENSOR_MAG_SPI_EXISTS && !SENSOR_DIRECT_MAG_EXISTS && !SENSOR_MAG_EXT_EXISTS
 	LOG_WRN("Magnetometer node does not exist");
 #endif
 	if (mag_id >= (int)ARRAY_SIZE(dev_mag_names))
@@ -699,10 +699,10 @@ int sensor_init(void)
 // 55-66ms to wait, get chip ids, and setup icm (50ms spent waiting for accel and gyro to start)
 	if (mag_available && mag_enabled)
 	{
-#if SENSOR_MAG_EXISTS
-		sensor_imu->ext_passthrough(true); // reenable passthrough
+#if SENSOR_DIRECT_MAG_EXISTS
+		sensor_imu->ext_setup(SENSOR_EXT_MODE_I2C_PASSTHROUGH); // reenable passthrough
 #elif SENSOR_MAG_EXT_EXISTS
-		sensor_imu->ext_setup();
+		sensor_imu->ext_setup(SENSOR_EXT_MODE_I2CM_PROXY); // todo, autonomous if possible
 #endif
 		err = sensor_mag->init(mag_initial_time, &mag_actual_time);
 		mag_interval = mag_actual_time * 1000 - 2; // start attemping magnetometer reads before expected new sample, ask for each sample 2ms earlier

--- a/src/sensor/sensor.c
+++ b/src/sensor/sensor.c
@@ -167,6 +167,11 @@ const char *sensor_get_sensor_fusion_name(void)
 	return fusion_names[fusion_id];
 }
 
+/**
+ * @param ptr last read sensor temperature
+ * @return int - 0 if success, -1 if there is IMU errors fetching the temperature or it's too early,
+ * -2 if there is no IMU connected
+ */
 int sensor_get_sensor_temperature(float *ptr)
 {
 	if (sensor_imu == &sensor_imu_none || (k_uptime_get() - last_temp_time > 1000))
@@ -654,19 +659,18 @@ static void sensor_update_sensor_state(void)
 int sensor_init(void)
 {
 	int err;
+	LOG_INF("Sensor init, shutdown first");
+	// TODO : Do not reset sensor if we just WOM'ed
 	// TODO: on any errors set main_ok false and skip (make functions return nonzero)
 	if (mag_available) // shutdown magnetometer first (in case of passthrough)
-		sensor_mag->shutdown(); // TODO: is this needed?
-	sensor_imu->shutdown(); // TODO: is this needed?
+		sensor_mag->shutdown();
+	sensor_imu->shutdown();
 
 	float clock_actual_rate = 0;
 	if (CONFIG_1_SETTINGS_READ(CONFIG_1_USE_SENSOR_CLOCK))
 		set_sensor_clock(true, 32768, &clock_actual_rate); // enable the clock source for IMU if present
 	if (clock_actual_rate != 0)
 		LOG_INF("Sensor clock rate: %.2fHz", (double)clock_actual_rate);
-
-	// wait for sensor register reset // TODO: is this needed?
-	k_usleep(250);
 
 	// set FS/range
 	float accel_range = CONFIG_2_SETTINGS_READ(CONFIG_2_SENSOR_ACCEL_FS);

--- a/src/sensor/sensor.h
+++ b/src/sensor/sensor.h
@@ -51,12 +51,20 @@ void main_imu_resume(void);
 void main_imu_wakeup(void);
 void main_imu_restart(void);
 
-enum sensor_ext_mode {
+typedef enum {
 	SENSOR_EXT_MODE_OFF = 0, // no external sensor
 	SENSOR_EXT_MODE_I2C_PASSTHROUGH = 1, // shorting external i2c bus to main i2c bus, mcu controls everything
 	SENSOR_EXT_MODE_I2CM_PROXY = 2, // separate buses, imu is as as a proxy / protocol to i2c converter
 	SENSOR_EXT_MODE_I2CM_AUTONOMOUS = 4, // separate buses, mag is autonomically driven by imu, data lands into fifo
-};
+} sensor_ext_mode_t;
+
+typedef enum {
+	DATA_VALID_ACCEL = 1,
+	DATA_VALID_GYRO = 2,
+	DATA_VALID_MAG = 4,
+	DATA_OUTSIDE_FIFO = 8,
+	DATA_INVALID = 16,
+} sensor_data_attrs_t;
 
 typedef struct sensor_fusion {
 	void (*init)(float, float, float); // gyro_time, accel_time, mag_time
@@ -104,7 +112,7 @@ typedef struct sensor_imu {
 	int (*update_odr)(float, float, float*, float*); // return actual update time, return 0 if success, 1 if odr is same, -1 if general error
 
 	uint16_t (*data_read)(uint8_t*, uint16_t);
-	int (*data_process)(uint16_t, uint8_t*, float[3], float[3], float[3]); // g, deg/s
+	sensor_data_attrs_t (*data_process)(uint16_t, uint8_t*, float[3], float[3], float[3]); // g, deg/s
 	void (*accel_read)(float[3]); // g
 	void (*gyro_read)(float[3]); // deg/s
 	int (*temp_read)(float*); // deg C, return 0 if success, -1 if error
@@ -112,7 +120,7 @@ typedef struct sensor_imu {
 	uint8_t (*setup_DRDY)(uint16_t);
 	uint8_t (*setup_WOM)(void);
 
-	int (*ext_setup)(enum sensor_ext_mode, const sensor_mag_t *mag, uint8_t mag_addr); // mag used for autonomous mode
+	int (*ext_setup)(sensor_ext_mode_t, const sensor_mag_t *mag, uint8_t mag_addr); // mag used for autonomous mode
 } sensor_imu_t;
 
 #endif

--- a/src/sensor/sensor.h
+++ b/src/sensor/sensor.h
@@ -78,30 +78,12 @@ typedef struct sensor_fusion {
 	void (*get_quat)(float *);
 } sensor_fusion_t;
 
-typedef struct sensor_imu {
-	int (*init)(float, float, float, float*, float*); // first float is clock_rate, nonzero means use CLKIN, return update time, return 0 if success, -1 if general error
-	void (*shutdown)(void);
-
-	void (*update_fs)(float, float, float*, float*); // return actual range
-	int (*update_odr)(float, float, float*, float*); // return actual update time, return 0 if success, 1 if odr is same, -1 if general error
-
-	uint16_t (*fifo_read)(uint8_t*, uint16_t);
-	int (*fifo_process)(uint16_t, uint8_t*, float[3], float[3]); // g, deg/s
-	void (*accel_read)(float[3]); // g
-	void (*gyro_read)(float[3]); // deg/s
-	int (*temp_read)(float*); // deg C, return 0 if success, -1 if error
-
-	uint8_t (*setup_DRDY)(uint16_t);
-	uint8_t (*setup_WOM)(void);
-
-	int (*ext_setup)(enum sensor_ext_mode);
-} sensor_imu_t;
-
 typedef struct sensor_mag {
 	int (*init)(float, float*); // return update time, return 0 if success, 1 if general error
 	void (*shutdown)(void);
 
-	int (*update_odr)(float, float*); // return actual update time, return 0 if success, 1 if odr is same, -1 if general error
+	int (*update_odr)(float, float*); // change update time, return real one, return 0 if success, 1 if odr is same, -1 if general error
+	float (*get_odr)(void); // return real update time
 
 	void (*mag_oneshot)(void); // trigger oneshot if exists
 	void (*mag_read)(float[3]); // any unit (usually gauss)
@@ -110,6 +92,27 @@ typedef struct sensor_mag {
 	void (*mag_process)(uint8_t*, float[3]); // use if magnetometer is present as an auxiliary sensor, from data read by IMU
 	uint8_t ext_min_burst; // minimum supported burst length for external interface
 	uint8_t ext_burst; // default supported burst length
+	uint8_t ext_dummy_bytes; // required dummy bytes to skip during every read
+	uint8_t ext_burst_reg; // first register address to read in burst
 } sensor_mag_t;
+
+typedef struct sensor_imu {
+	int (*init)(float, float, float, float*, float*); // first float is clock_rate, nonzero means use CLKIN, return update time, return 0 if success, -1 if general error
+	void (*shutdown)(void);
+
+	void (*update_fs)(float, float, float*, float*); // return actual range
+	int (*update_odr)(float, float, float*, float*); // return actual update time, return 0 if success, 1 if odr is same, -1 if general error
+
+	uint16_t (*data_read)(uint8_t*, uint16_t);
+	int (*data_process)(uint16_t, uint8_t*, float[3], float[3], float[3]); // g, deg/s
+	void (*accel_read)(float[3]); // g
+	void (*gyro_read)(float[3]); // deg/s
+	int (*temp_read)(float*); // deg C, return 0 if success, -1 if error
+
+	uint8_t (*setup_DRDY)(uint16_t);
+	uint8_t (*setup_WOM)(void);
+
+	int (*ext_setup)(enum sensor_ext_mode, const sensor_mag_t *mag, uint8_t mag_addr); // mag used for autonomous mode
+} sensor_imu_t;
 
 #endif

--- a/src/sensor/sensor.h
+++ b/src/sensor/sensor.h
@@ -51,6 +51,13 @@ void main_imu_resume(void);
 void main_imu_wakeup(void);
 void main_imu_restart(void);
 
+enum sensor_ext_mode {
+	SENSOR_EXT_MODE_OFF = 0, // no external sensor
+	SENSOR_EXT_MODE_I2C_PASSTHROUGH = 1, // shorting external i2c bus to main i2c bus, mcu controls everything
+	SENSOR_EXT_MODE_I2CM_PROXY = 2, // separate buses, imu is as as a proxy / protocol to i2c converter
+	SENSOR_EXT_MODE_I2CM_AUTONOMOUS = 4, // separate buses, mag is autonomically driven by imu, data lands into fifo
+};
+
 typedef struct sensor_fusion {
 	void (*init)(float, float, float); // gyro_time, accel_time, mag_time
 	void (*load)(const void *);
@@ -87,8 +94,7 @@ typedef struct sensor_imu {
 	uint8_t (*setup_DRDY)(uint16_t);
 	uint8_t (*setup_WOM)(void);
 
-	int (*ext_setup)(void); // register write/writeread with interface, return 0 if success, -1 if error or not available
-	int (*ext_passthrough)(bool); // enable/disable passthrough mode, return 0 if success, -1 if error or not available
+	int (*ext_setup)(enum sensor_ext_mode);
 } sensor_imu_t;
 
 typedef struct sensor_mag {

--- a/src/sensor/sensor_none.c
+++ b/src/sensor/sensor_none.c
@@ -50,15 +50,15 @@ int imu_none_update_odr(float accel_time, float gyro_time, float *accel_actual_t
 	return -1;
 }
 
-uint16_t imu_none_fifo_read(uint8_t *data, uint16_t len)
+uint16_t imu_none_data_read(uint8_t *data, uint16_t len)
 {
-	LOG_DBG("imu_none_fifo_read, sensor has no IMU or IMU has no FIFO");
+	LOG_DBG("imu_none_data_read, sensor has no IMU or IMU has no FIFO");
 	return 0;
 }
 
-int imu_none_fifo_process(uint16_t index, uint8_t *data, float a[3], float g[3])
+int imu_none_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
 {
-	LOG_DBG("imu_none_fifo_process, sensor has no IMU or IMU has no FIFO");
+	LOG_DBG("imu_none_data_process, sensor has no IMU or IMU has no FIFO");
 	return -1;
 }
 
@@ -92,7 +92,7 @@ uint8_t imu_none_setup_WOM(void)
 	return 0;
 }
 
-int imu_none_ext_setup(enum sensor_ext_mode)
+int imu_none_ext_setup(enum sensor_ext_mode, const sensor_mag_t *mag, uint8_t mag_addr)
 {
 	LOG_DBG("imu_none_ext_setup, sensor has no IMU or IMU has no ext support");
 	return -1;
@@ -105,8 +105,8 @@ const sensor_imu_t sensor_imu_none = {
 	*imu_none_update_fs,
 	*imu_none_update_odr,
 
-	*imu_none_fifo_read,
-	*imu_none_fifo_process,
+	*imu_none_data_read,
+	*imu_none_data_process,
 	*imu_none_accel_read,
 	*imu_none_gyro_read,
 	*imu_none_temp_read,
@@ -133,6 +133,11 @@ int mag_none_update_odr(float time, float *actual_time)
 {
 	LOG_DBG("mag_none_update_odr, sensor has no magnetometer or magnetometer has no configurable ODR");
 	return -1;
+}
+
+float mag_none_get_odr(void)
+{
+	return 0.0f;
 }
 
 void mag_none_mag_oneshot(void)
@@ -164,6 +169,7 @@ const sensor_mag_t sensor_mag_none = {
 	*mag_none_shutdown,
 
 	*mag_none_update_odr,
+	*mag_none_get_odr,
 
 	*mag_none_mag_oneshot,
 	*mag_none_mag_read,

--- a/src/sensor/sensor_none.c
+++ b/src/sensor/sensor_none.c
@@ -92,15 +92,9 @@ uint8_t imu_none_setup_WOM(void)
 	return 0;
 }
 
-int imu_none_ext_setup(void)
+int imu_none_ext_setup(enum sensor_ext_mode)
 {
 	LOG_DBG("imu_none_ext_setup, sensor has no IMU or IMU has no ext support");
-	return -1;
-}
-
-int imu_none_ext_passthrough(bool passthrough)
-{
-	LOG_DBG("imu_none_ext_passthrough, sensor has no IMU or IMU has no ext passthrough");
 	return -1;
 }
 
@@ -120,8 +114,7 @@ const sensor_imu_t sensor_imu_none = {
 	*imu_none_setup_DRDY,
 	*imu_none_setup_WOM,
 	
-	*imu_none_ext_setup,
-	*imu_none_ext_passthrough
+	*imu_none_ext_setup
 };
 
 int mag_none_init(float time, float *actual_time)

--- a/src/sensor/sensor_none.c
+++ b/src/sensor/sensor_none.c
@@ -56,7 +56,7 @@ uint16_t imu_none_data_read(uint8_t *data, uint16_t len)
 	return 0;
 }
 
-int imu_none_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
+sensor_data_attrs_t imu_none_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3])
 {
 	LOG_DBG("imu_none_data_process, sensor has no IMU or IMU has no FIFO");
 	return -1;
@@ -92,7 +92,7 @@ uint8_t imu_none_setup_WOM(void)
 	return 0;
 }
 
-int imu_none_ext_setup(enum sensor_ext_mode, const sensor_mag_t *mag, uint8_t mag_addr)
+int imu_none_ext_setup(sensor_ext_mode_t, const sensor_mag_t *mag, uint8_t mag_addr)
 {
 	LOG_DBG("imu_none_ext_setup, sensor has no IMU or IMU has no ext support");
 	return -1;

--- a/src/sensor/sensor_none.h
+++ b/src/sensor/sensor_none.h
@@ -31,14 +31,14 @@ void imu_none_shutdown(void);
 int imu_none_update_odr(float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time);
 
 uint16_t imu_none_data_read(uint8_t *data, uint16_t len);
-int imu_none_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3]);
+sensor_data_attrs_t imu_none_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3]);
 void imu_none_accel_read(float a[3]);
 void imu_none_gyro_read(float g[3]);
 int imu_none_temp_read(float *data);
 
 uint8_t imu_none_setup_WOM(void);
 
-int imu_none_ext_setup(enum sensor_ext_mode, const sensor_mag_t *mag, uint8_t mag_addr);
+int imu_none_ext_setup(sensor_ext_mode_t, const sensor_mag_t *mag, uint8_t mag_addr);
 
 extern const sensor_imu_t sensor_imu_none;
 

--- a/src/sensor/sensor_none.h
+++ b/src/sensor/sensor_none.h
@@ -30,15 +30,15 @@ void imu_none_shutdown(void);
 
 int imu_none_update_odr(float accel_time, float gyro_time, float *accel_actual_time, float *gyro_actual_time);
 
-uint16_t imu_none_fifo_read(uint8_t *data, uint16_t len);
-int imu_none_fifo_process(uint16_t index, uint8_t *data, float a[3], float g[3]);
+uint16_t imu_none_data_read(uint8_t *data, uint16_t len);
+int imu_none_data_process(uint16_t index, uint8_t *data, float a[3], float g[3], float m[3]);
 void imu_none_accel_read(float a[3]);
 void imu_none_gyro_read(float g[3]);
 int imu_none_temp_read(float *data);
 
 uint8_t imu_none_setup_WOM(void);
 
-int imu_none_ext_setup(enum sensor_ext_mode);
+int imu_none_ext_setup(enum sensor_ext_mode, const sensor_mag_t *mag, uint8_t mag_addr);
 
 extern const sensor_imu_t sensor_imu_none;
 
@@ -46,6 +46,7 @@ int mag_none_init(float time, float *actual_time);
 void mag_none_shutdown(void);
 
 int mag_none_update_odr(float time, float *actual_time);
+float mag_none_get_odr(void);
 
 void mag_none_mag_oneshot(void);
 void mag_none_mag_read(float m[3]);

--- a/src/sensor/sensor_none.h
+++ b/src/sensor/sensor_none.h
@@ -38,8 +38,7 @@ int imu_none_temp_read(float *data);
 
 uint8_t imu_none_setup_WOM(void);
 
-int imu_none_ext_setup(void);
-int imu_none_ext_passthrough(bool passthrough);
+int imu_none_ext_setup(enum sensor_ext_mode);
 
 extern const sensor_imu_t sensor_imu_none;
 

--- a/src/system/battery.c
+++ b/src/system/battery.c
@@ -16,6 +16,13 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/logging/log.h>
 
+#if __has_include(<zephyr/dt-bindings/adc/nrf-saadc-v3.h>)
+#include <zephyr/dt-bindings/adc/nrf-saadc-v3.h>
+#else
+#include <zephyr/dt-bindings/adc/nrf-saadc.h>
+#endif
+
+
 #include "battery.h"
 
 LOG_MODULE_REGISTER(BATTERY, CONFIG_ADC_LOG_LEVEL);
@@ -131,16 +138,20 @@ static int divider_setup(void)
 		.acquisition_time = ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 3),
 	};
 
+	// TODO: cam this fine tuning be moved somehow to device tree? this is jank
+
 	if (cfg->output_ohm != 0) {
+#if NCS_VERSION_MAJOR <= 3 && NCS_VERSION_MINOR <= 1
 		accp->input_positive = 1 + iocp->channel; // <=sdk 3.1 SAADC_CH_PSELP_PSELP_AnalogInput0
-//		accp->input_positive = iocp->channel; // >=sdk 3.2.0, SAADC_CH_PSELP_PSELP_AnalogInput0 does not match! Instead use NRF_SAADC_AIN0
+#else
+		accp->input_positive = iocp->channel; // >=sdk 3.2.0, SAADC_CH_PSELP_PSELP_AnalogInput0 does not match! Instead use NRF_SAADC_AIN0
+#endif
 	} else {
 		accp->input_positive = 9; // SAADC_CH_PSELP_PSELP_VDD
 	}
 
-	if (iocp->channel == 12) { // VDDHDIV5
-		// <=sdk 3.1 SAADC_CH_PSELP_PSELP_VDDHDIV5
-//		accp->input_positive = 128 + 4; // >=sdk 3.2.0, SAADC_CH_PSELP_PSELP_VDDHDIV5 does not match! Instead use NRF_SAADC_VDDHDIV5
+	if (iocp->channel == NRF_SAADC_VDDHDIV5) { // VDDHDIV5
+		accp->input_positive = NRF_SAADC_VDDHDIV5;
 		asp->oversampling = 2;
 		accp->acquisition_time = ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 10);
 	}

--- a/src/system/power.h
+++ b/src/system/power.h
@@ -4,10 +4,10 @@
 void sys_interface_suspend(void);
 void sys_interface_resume(void);
 
-void sys_request_WOM(bool, bool);
-void sys_request_system_off(bool);
-void sys_request_system_reboot(bool);
-void sys_request_system_silent_off(bool);
+void sys_request_WOM(bool force, bool immediate);
+void sys_request_system_off(bool immediate);
+void sys_request_system_reboot(bool immediate);
+void sys_request_system_silent_off(bool immediate);
 
 bool vin_read(void);
 

--- a/src/system/system.c
+++ b/src/system/system.c
@@ -81,6 +81,10 @@ static const struct pwm_dt_spec clk_out = {0};
 static const struct device *gpio_dev = DEVICE_DT_GET(DT_NODELABEL(gpio0));
 #endif
 
+/**
+ * @param ptr current chip die temperature
+ * @return int - 0 if success, -1 if the temperature is not available yet
+ */
 int sys_get_die_temperature(float *ptr)
 {
 	if (k_uptime_get() - last_temp_time > 1000)

--- a/src/usb.c
+++ b/src/usb.c
@@ -19,7 +19,7 @@ static bool configured;
 LOG_MODULE_REGISTER(usb, LOG_LEVEL_INF);
 
 static void usb_init_thread(void);
-K_THREAD_DEFINE(usb_init_thread_id, 256, usb_init_thread, NULL, NULL, NULL, USB_INIT_THREAD_PRIORITY, 0, 500); // Wait before enabling USB
+K_THREAD_DEFINE(usb_init_thread_id, 512, usb_init_thread, NULL, NULL, NULL, USB_INIT_THREAD_PRIORITY, 0, 500); // Wait before enabling USB
 
 static void status_cb(enum usb_dc_status_code status, const uint8_t *param)
 {


### PR DESCRIPTION
Hi.

This is my ~~first~~ second contact with nrf firmware, so it might be janky.

Update firmware to compile and work on 3.2.5 SDK, I found issues in USB init thread crashing because of too small stack and ADC reading wrong channel. Current code should work on both 3.1.x and 3.2.x toolchains.

Fixed calibration commands not triggering first time.

Pulled https://github.com/SlimeVR/SlimeVR-Tracker-nRF/pull/105 and fixed by re-enabling ext interface and correctly setting DEV_PROFILE_* regs when needed.

Fixed QMC6309 mistakenly working in max ODR possible, even though it was read way less often. Fixed that mag reporting data not ready if read was longer that 2ms (even though data was ready). Changed mag real sampling rate to be 2ms shorter of target instead of 90% length to avoid many empty reads. Not sure if mag data is correct (how to calibrate that?), but at least there is some mag data now.